### PR TITLE
Add home directory expansion (~) in string literals

### DIFF
--- a/examples/blur.pic
+++ b/examples/blur.pic
@@ -1,4 +1,4 @@
-img = load_image("/home/rober/Pictures/cat.png")
+img = load_image("~/Pictures/cat.png")
 blurred_img = blur(img, gaussian)
 show_image(blurred_img)
 save_image(blurred_img, "blurred_cat.jpg")

--- a/examples/box_blur.pic
+++ b/examples/box_blur.pic
@@ -1,4 +1,4 @@
-img = load_image("/home/atamas19/Pictures/cat.png")
+img = load_image("~/Pictures/cat.png")
 show_image(img)
 box_blur_img = box_blur(img, 7)
 show_image(box_blur_img)

--- a/examples/brightness.pic
+++ b/examples/brightness.pic
@@ -1,5 +1,4 @@
-img = load_image("/home/rober/Pictures/cat.png")
+img = load_image("~/Pictures/cat.png")
 show_image(img)
 brighter_img = brightness(img, 100)
-show_image(img)
 show_image(brighter_img)

--- a/examples/convolution.pic
+++ b/examples/convolution.pic
@@ -1,4 +1,4 @@
-img = load_image("/home/rober/Pictures/cat.png")
+img = load_image("~/Pictures/cat.png")
 kernel = [[-1, -1, -1],
           [-1,  8, -1],
           [-1, -1, -1]]
@@ -7,4 +7,3 @@ show_image(img)
 
 show_image(convolution_img)
 save_image(convolution_img, "testme.png")
-

--- a/examples/edge_detect.pic
+++ b/examples/edge_detect.pic
@@ -1,4 +1,4 @@
-img = load_image("/home/atamas19/Pictures/cat.png")
+img = load_image("~/Pictures/cat.png")
 show_image(img)
 edge_detect_img = edge_detect(img)
 show_image(edge_detect_img)

--- a/examples/emboss.pic
+++ b/examples/emboss.pic
@@ -1,4 +1,4 @@
-img = load_image("/home/atamas19/Pictures/cat.png")
+img = load_image("~/Pictures/cat.png")
 show_image(img)
 emboss_img = emboss(img)
 show_image(emboss_img)

--- a/examples/gaussian_blur.pic
+++ b/examples/gaussian_blur.pic
@@ -1,4 +1,4 @@
-img = load_image("/home/atamas19/Pictures/cat.png")
+img = load_image("~/Pictures/cat.png")
 show_image(img)
 gaussian_blur_img = gaussian_blur(img, 7)
 show_image(gaussian_blur_img)

--- a/examples/invert.pic
+++ b/examples/invert.pic
@@ -1,4 +1,4 @@
-img = load_image("/home/rober/Pictures/cat.png")
+img = load_image("~/Pictures/cat.png")
 show_image(img)
 inverted = invert(img)
 show_image(img)

--- a/examples/sharpen.pic
+++ b/examples/sharpen.pic
@@ -1,4 +1,4 @@
-img = load_image("/home/atamas19/Pictures/cat.png")
+img = load_image("~/Pictures/cat.png")
 show_image(img)
 sharpen_img = sharpen(img, 50)
 show_image(sharpen_img)

--- a/include/utils.h
+++ b/include/utils.h
@@ -12,6 +12,22 @@
 
 namespace picceler::utils {
 
+/**
+ * Expands a leading tilde in a filesystem path to the current user's home directory.
+ *
+ * On POSIX systems, this uses the HOME environment variable when available and
+ * falls back to getpwuid(getuid()) if HOME is not set. On Windows, it uses the
+ * USERPROFILE environment variable, or HOMEDRIVE + HOMEPATH if USERPROFILE is
+ * not available.
+ *
+ * If the input does not begin with '~', or if the home directory cannot be
+ * determined (e.g., required environment variables are unset and system calls
+ * fail), the original inputPath is returned unchanged.
+ *
+ * @param inputPath Path string that may start with '~' to refer to the user's home.
+ * @return A string where a leading '~' has been replaced by the user's home
+ *         directory, or the original inputPath if no expansion is performed.
+ */
 std::string expandTilde(const std::string& inputPath);
 
 } // namespace picceler::utils

--- a/include/utils.h
+++ b/include/utils.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+#include <cstdlib>
+
+#ifndef _WIN32
+#include <unistd.h>
+#include <sys/types.h>
+#include <pwd.h>
+#endif
+
+namespace picceler::utils {
+
+std::string expandTilde(const std::string& inputPath);
+
+} // namespace picceler::utils

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,6 +13,14 @@ target_link_libraries(PiccelerGlobalDeps INTERFACE
     spdlog::spdlog
 )
 
+add_library(PiccelerUtils STATIC
+    utils.cpp
+)
+
+target_link_libraries(PiccelerUtils PUBLIC
+    PiccelerGlobalDeps
+)
+
 add_library(PiccelerFrontend STATIC
     lexer.cpp
     ast.cpp
@@ -21,6 +29,7 @@ add_library(PiccelerFrontend STATIC
 
 target_link_libraries(PiccelerFrontend PUBLIC 
     PiccelerGlobalDeps
+    PiccelerUtils
 )
 
 add_library(PiccelerIR STATIC

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -151,7 +151,7 @@ bool Compiler::emitObjectFile(llvm::Module *llvmModule, const std::string &objFi
 bool Compiler::linkWithLLD(const std::string &objFile, const std::string &runtimeLib, const std::string &outputExe) {
   // Build the link command using clang++ with -no-pie to avoid PIE relocations
   std::string cmd =
-      "clang++ " + objFile + " " + runtimeLib + " -o " + outputExe + " -no-pie $(pkg-config --libs opencv4) -lfmt -lspdlog";
+      "clang++ " + objFile + " " + runtimeLib + " -o " + outputExe + " -no-pie $(pkg-config --libs opencv4)";
   spdlog::debug("Linking with command: {}", cmd);
 
   int ret = std::system(cmd.c_str());

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -151,7 +151,7 @@ bool Compiler::emitObjectFile(llvm::Module *llvmModule, const std::string &objFi
 bool Compiler::linkWithLLD(const std::string &objFile, const std::string &runtimeLib, const std::string &outputExe) {
   // Build the link command using clang++ with -no-pie to avoid PIE relocations
   std::string cmd =
-      "clang++ " + objFile + " " + runtimeLib + " -o " + outputExe + " -no-pie $(pkg-config --libs opencv4)";
+      "clang++ " + objFile + " " + runtimeLib + " -o " + outputExe + " -no-pie $(pkg-config --libs opencv4) -lfmt -lspdlog";
   spdlog::debug("Linking with command: {}", cmd);
 
   int ret = std::system(cmd.c_str());

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -390,7 +390,7 @@ Result<std::unique_ptr<ASTNode>> Parser::parseString() {
     return std::unexpected(CompileError{std::format("Expected string at {}:{}", token._line, token._column)});
   }
   auto strNode = std::make_unique<StringNode>();
-  // TODO: Implement a compiler flag to let the user not expand tilde if it's not needed
+  // TODO: Implement a compiler flag to let the user not expand tilde if it is not needed
   strNode->value = utils::expandTilde(token._value);
   return strNode;
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -390,11 +390,8 @@ Result<std::unique_ptr<ASTNode>> Parser::parseString() {
     return std::unexpected(CompileError{std::format("Expected string at {}:{}", token._line, token._column)});
   }
   auto strNode = std::make_unique<StringNode>();
-  if (!token._value.empty() && token._value[0] == '~') {
-    strNode->value = utils::expandTilde(token._value);
-  } else {
-    strNode->value = token._value;
-  }
+  // TODO: Implement a compiler flag to let the user not expand tilde if it's not needed
+  strNode->value = utils::expandTilde(token._value);
   return strNode;
 }
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -5,6 +5,7 @@
 
 #include "spdlog/spdlog.h"
 #include "error.h"
+#include "utils.h"
 
 using namespace picceler;
 
@@ -389,7 +390,11 @@ Result<std::unique_ptr<ASTNode>> Parser::parseString() {
     return std::unexpected(CompileError{std::format("Expected string at {}:{}", token._line, token._column)});
   }
   auto strNode = std::make_unique<StringNode>();
-  strNode->value = token._value;
+  if (!token._value.empty() && token._value[0] == '~') {
+    strNode->value = utils::expandTilde(token._value);
+  } else {
+    strNode->value = token._value;
+  }
   return strNode;
 }
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,0 +1,49 @@
+#include "utils.h"
+
+namespace picceler::utils {
+
+std::string expandTilde(const std::string& inputPath) {
+    if (inputPath.empty() || inputPath[0] != '~') {
+        return inputPath;
+    }
+
+    std::filesystem::path homePath;
+
+#ifdef _WIN32
+    const char* userProfile = std::getenv("USERPROFILE");
+    if (!userProfile) {
+        const char* hd = std::getenv("HOMEDRIVE");
+        const char* hp = std::getenv("HOMEPATH");
+        if (hd && hp) {
+            homePath = std::string(hd) + std::string(hp);
+        } else {
+            return inputPath;
+        }
+    } else {
+        homePath = userProfile;
+    }
+#else
+    const char* homeEnv = std::getenv("HOME");
+    if (homeEnv) {
+        homePath = homeEnv;
+    } else {
+        struct passwd* pw = getpwuid(getuid());
+        if (pw) {
+            homePath = pw->pw_dir;
+        } else {
+            return inputPath;
+        }
+    }
+#endif
+    std::string remainder = inputPath.substr(1);
+
+    if (!remainder.empty() && (remainder[0] == '/' || remainder[0] == '\\')) {
+        remainder = remainder.substr(1);
+    }
+
+    homePath /= remainder;
+
+    return homePath.string(); 
+}
+
+} // namespace picceler::utils

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -43,7 +43,7 @@ std::string expandTilde(const std::string& inputPath) {
 
     homePath /= remainder;
 
-    return homePath.string(); 
+    return homePath.string();
 }
 
 } // namespace picceler::utils


### PR DESCRIPTION
This PR implements automatic shell-like expansion for the tilde character `~` in string literals. This allows users to reference files relative to their home directory (e.g., ~/Pictures/test.png) without needing to hardcode absolute paths.