### PR TITLE
Added 2 tests for kernel to memref pass

### DIFF
--- a/tablegen/passes.td
+++ b/tablegen/passes.td
@@ -18,6 +18,12 @@ def PiccelerFiltersToConv : Pass<"picceler-filters-to-conv", "mlir::ModuleOp"> {
 def PiccelerKernelToMemref : Pass<"picceler-kernel-to-memref", "mlir::ModuleOp"> {
   let summary = "Lower Picceler Kernel Ops to Memref Ops";
   let constructor = "picceler::createPiccelerKernelToMemrefPass()";
+
+  let dependentDialects = [
+    "mlir::LLVM::LLVMDialect",
+    "mlir::arith::ArithDialect",
+    "mlir::memref::MemRefDialect"
+    ];
 }
 
 def PiccelerToAffine : Pass<"picceler-to-affine", "mlir::ModuleOp"> {

--- a/tablegen/passes.td
+++ b/tablegen/passes.td
@@ -20,7 +20,6 @@ def PiccelerKernelToMemref : Pass<"picceler-kernel-to-memref", "mlir::ModuleOp">
   let constructor = "picceler::createPiccelerKernelToMemrefPass()";
 
   let dependentDialects = [
-    "mlir::LLVM::LLVMDialect",
     "mlir::arith::ArithDialect",
     "mlir::memref::MemRefDialect"
     ];

--- a/tests/lit/mlir/picceler_kernel_to_memref_pass.mlir
+++ b/tests/lit/mlir/picceler_kernel_to_memref_pass.mlir
@@ -1,0 +1,49 @@
+// RUN: %picceler-opt --picceler-kernel-to-memref -split-input-file %s | FileCheck %s
+
+
+func.func @SmallKernelOfOnes() {
+    %0 = "picceler.kernel.const"() <{values = dense<1.000000e+00> : tensor<3x3xf64>}> : () -> !picceler.kernel<3 x 3>
+    return 
+}
+
+// CHECK-LABEL: func.func @SmallKernelOfOnes()
+// CHECK-DAG: %[[KERNEL_VALUE:.*]] = arith.constant 1.000000e+00 : f64
+// CHECK-DAG: %[[INDEX_0:.*]] = arith.constant 0 : index
+// CHECK-DAG: %[[INDEX_1:.*]] = arith.constant 1 : index
+// CHECK-DAG: %[[INDEX_2:.*]] = arith.constant 2 : index
+// CHECK: %[[MEMREF:.*]] = memref.alloca() : memref<3x3xf64>
+// CHECK: memref.store %[[KERNEL_VALUE]], %[[MEMREF]][%[[INDEX_0]], %[[INDEX_0]]]  : memref<3x3xf64>
+// CHECK: memref.store %[[KERNEL_VALUE]], %[[MEMREF]][%[[INDEX_0]], %[[INDEX_1]]] : memref<3x3xf64>
+// CHECK: memref.store %[[KERNEL_VALUE]], %[[MEMREF]][%[[INDEX_0]], %[[INDEX_2]]] : memref<3x3xf64>
+// CHECK: memref.store %[[KERNEL_VALUE]], %[[MEMREF]][%[[INDEX_1]], %[[INDEX_0]]] : memref<3x3xf64>
+// CHECK: memref.store %[[KERNEL_VALUE]], %[[MEMREF]][%[[INDEX_1]], %[[INDEX_1]]] : memref<3x3xf64>
+// CHECK: memref.store %[[KERNEL_VALUE]], %[[MEMREF]][%[[INDEX_1]], %[[INDEX_2]]] : memref<3x3xf64>
+// CHECK: memref.store %[[KERNEL_VALUE]], %[[MEMREF]][%[[INDEX_2]], %[[INDEX_0]]] : memref<3x3xf64>
+// CHECK: memref.store %[[KERNEL_VALUE]], %[[MEMREF]][%[[INDEX_2]], %[[INDEX_1]]] : memref<3x3xf64>
+// CHECK: memref.store %[[KERNEL_VALUE]], %[[MEMREF]][%[[INDEX_2]], %[[INDEX_2]]] : memref<3x3xf64>
+// CHECK-NEXT: return 
+
+// -----
+
+func.func @VerticalLineKernel() {
+    %0 = "picceler.kernel.const"() <{values = dense<[[-1.000000e+00, 2.000000e+00, -1.000000e+00], [-1.000000e+00, 2.000000e+00, -1.000000e+00], [-1.000000e+00, 2.000000e+00, -1.000000e+00]]> : tensor<3x3xf64>}> : () -> !picceler.kernel<3 x 3>
+    return 
+}
+
+// CHECK-LABEL: func.func @VerticalLineKernel()
+// CHECK-DAG: %[[NEG1:.*]] = arith.constant -1.000000e+00 : f64
+// CHECK-DAG: %[[POS2:.*]] = arith.constant 2.000000e+00 : f64
+// CHECK-DAG: %[[INDEX_0:.*]] = arith.constant 0 : index
+// CHECK-DAG: %[[INDEX_1:.*]] = arith.constant 1 : index
+// CHECK-DAG: %[[INDEX_2:.*]] = arith.constant 2 : index
+// CHECK: %[[MEMREF:.*]] = memref.alloca() : memref<3x3xf64>
+// CHECK-NEXT: memref.store %[[NEG1]], %[[MEMREF]][%[[INDEX_0]], %[[INDEX_0]]] : memref<3x3xf64>
+// CHECK-NEXT: memref.store %[[POS2]], %[[MEMREF]][%[[INDEX_0]], %[[INDEX_1]]] : memref<3x3xf64>
+// CHECK-NEXT: memref.store %[[NEG1]], %[[MEMREF]][%[[INDEX_0]], %[[INDEX_2]]] : memref<3x3xf64>
+// CHECK-NEXT: memref.store %[[NEG1]], %[[MEMREF]][%[[INDEX_1]], %[[INDEX_0]]] : memref<3x3xf64>
+// CHECK-NEXT: memref.store %[[POS2]], %[[MEMREF]][%[[INDEX_1]], %[[INDEX_1]]] : memref<3x3xf64>
+// CHECK-NEXT: memref.store %[[NEG1]], %[[MEMREF]][%[[INDEX_1]], %[[INDEX_2]]] : memref<3x3xf64>
+// CHECK-NEXT: memref.store %[[NEG1]], %[[MEMREF]][%[[INDEX_2]], %[[INDEX_0]]] : memref<3x3xf64>
+// CHECK-NEXT: memref.store %[[POS2]], %[[MEMREF]][%[[INDEX_2]], %[[INDEX_1]]] : memref<3x3xf64>
+// CHECK-NEXT: memref.store %[[NEG1]], %[[MEMREF]][%[[INDEX_2]], %[[INDEX_2]]] : memref<3x3xf64>
+// CHECK-NEXT: return

--- a/tests/lit/mlir/picceler_kernel_to_memref_pass.mlir
+++ b/tests/lit/mlir/picceler_kernel_to_memref_pass.mlir
@@ -21,7 +21,7 @@ func.func @SmallKernelOfOnes() {
 // CHECK: memref.store %[[KERNEL_VALUE]], %[[MEMREF]][%[[INDEX_2]], %[[INDEX_0]]] : memref<3x3xf64>
 // CHECK: memref.store %[[KERNEL_VALUE]], %[[MEMREF]][%[[INDEX_2]], %[[INDEX_1]]] : memref<3x3xf64>
 // CHECK: memref.store %[[KERNEL_VALUE]], %[[MEMREF]][%[[INDEX_2]], %[[INDEX_2]]] : memref<3x3xf64>
-// CHECK-NEXT: return 
+// CHECK-NEXT: return
 
 // -----
 
@@ -37,13 +37,14 @@ func.func @VerticalLineKernel() {
 // CHECK-DAG: %[[INDEX_1:.*]] = arith.constant 1 : index
 // CHECK-DAG: %[[INDEX_2:.*]] = arith.constant 2 : index
 // CHECK: %[[MEMREF:.*]] = memref.alloca() : memref<3x3xf64>
-// CHECK-NEXT: memref.store %[[NEG1]], %[[MEMREF]][%[[INDEX_0]], %[[INDEX_0]]] : memref<3x3xf64>
-// CHECK-NEXT: memref.store %[[POS2]], %[[MEMREF]][%[[INDEX_0]], %[[INDEX_1]]] : memref<3x3xf64>
-// CHECK-NEXT: memref.store %[[NEG1]], %[[MEMREF]][%[[INDEX_0]], %[[INDEX_2]]] : memref<3x3xf64>
-// CHECK-NEXT: memref.store %[[NEG1]], %[[MEMREF]][%[[INDEX_1]], %[[INDEX_0]]] : memref<3x3xf64>
-// CHECK-NEXT: memref.store %[[POS2]], %[[MEMREF]][%[[INDEX_1]], %[[INDEX_1]]] : memref<3x3xf64>
-// CHECK-NEXT: memref.store %[[NEG1]], %[[MEMREF]][%[[INDEX_1]], %[[INDEX_2]]] : memref<3x3xf64>
-// CHECK-NEXT: memref.store %[[NEG1]], %[[MEMREF]][%[[INDEX_2]], %[[INDEX_0]]] : memref<3x3xf64>
-// CHECK-NEXT: memref.store %[[POS2]], %[[MEMREF]][%[[INDEX_2]], %[[INDEX_1]]] : memref<3x3xf64>
-// CHECK-NEXT: memref.store %[[NEG1]], %[[MEMREF]][%[[INDEX_2]], %[[INDEX_2]]] : memref<3x3xf64>
+// CHECK: memref.store %[[NEG1]], %[[MEMREF]][%[[INDEX_0]], %[[INDEX_0]]] : memref<3x3xf64>
+// CHECK: memref.store %[[POS2]], %[[MEMREF]][%[[INDEX_0]], %[[INDEX_1]]] : memref<3x3xf64>
+// CHECK: memref.store %[[NEG1]], %[[MEMREF]][%[[INDEX_0]], %[[INDEX_2]]] : memref<3x3xf64>
+// CHECK: memref.store %[[NEG1]], %[[MEMREF]][%[[INDEX_1]], %[[INDEX_0]]] : memref<3x3xf64>
+// CHECK: memref.store %[[POS2]], %[[MEMREF]][%[[INDEX_1]], %[[INDEX_1]]] : memref<3x3xf64>
+// CHECK: memref.store %[[NEG1]], %[[MEMREF]][%[[INDEX_1]], %[[INDEX_2]]] : memref<3x3xf64>
+// CHECK: memref.store %[[NEG1]], %[[MEMREF]][%[[INDEX_2]], %[[INDEX_0]]] : memref<3x3xf64>
+// CHECK: memref.store %[[POS2]], %[[MEMREF]][%[[INDEX_2]], %[[INDEX_1]]] : memref<3x3xf64>
+// CHECK: memref.store %[[NEG1]], %[[MEMREF]][%[[INDEX_2]], %[[INDEX_2]]] : memref<3x3xf64>
 // CHECK-NEXT: return
+

--- a/tools/picceler-opt/main.cpp
+++ b/tools/picceler-opt/main.cpp
@@ -14,6 +14,7 @@ int main(int argc, char **argv) {
 
   registry.insert<picceler::PiccelerDialect>();
   registry.insert<mlir::LLVM::LLVMDialect>();
+  registry.insert<mlir::memref::MemRefDialect>();
   picceler::registerPasses();
 
   return mlir::asMainReturnCode(mlir::MlirOptMain(argc, argv, "Picceler optimizer driver\n", registry));


### PR DESCRIPTION
This PR adds 2 MLIR LIT tests for kernel-to-memref pass, one with a simple all 1s kernel and one for vertical line detection