### PR TITLE
Implement neighborhood-like operations: Dilate, Erode, and Convolution

### DIFF
--- a/examples/dilate.pic
+++ b/examples/dilate.pic
@@ -1,0 +1,5 @@
+cat = load_image("~/Pictures/cat.png")
+
+dilated_cat = dilate(cat, 3)
+
+show_image(dilated_cat)

--- a/examples/erode.pic
+++ b/examples/erode.pic
@@ -1,0 +1,5 @@
+cat = load_image("~/Pictures/cat.png")
+
+eroded_cat = erode(cat, 3)
+
+show_image(eroded_cat)

--- a/include/ops.h
+++ b/include/ops.h
@@ -8,7 +8,10 @@
 #include "mlir/Support/LLVM.h"
 #include "llvm/ADT/TypeSwitch.h"
 
+#include <utility>
+
 #include "types.h"
+#include "piccelerInterfaces.h.inc"
 
 #define GET_OP_CLASSES
 #include "piccelerOps.h.inc"

--- a/lib/include/runtime.h
+++ b/lib/include/runtime.h
@@ -12,7 +12,6 @@ extern "C" {
  */
 
 picceler::Image *piccelerLoadImage(const char *filename);
-picceler::Image piccelerBlurImage(picceler::Image image, const char *mode);
 void piccelerShowImage(picceler::Image *image);
 void piccelerSaveImage(picceler::Image *image, const char *filename);
 picceler::Image *piccelerCreateImage(uint32_t width, uint32_t height);

--- a/src/mlir_gen.cpp
+++ b/src/mlir_gen.cpp
@@ -139,12 +139,6 @@ mlir::Value MLIRGen::emitBuiltinCall(CallNode *node, const std::vector<mlir::Val
     auto filename = args[0];
     auto callOp = _builder.create<LoadImageOp>(_builder.getUnknownLoc(), imageType, filename);
     return callOp.getResult();
-  } else if (name == "blur") {
-    auto imageType = _builder.getType<ImageType>();
-    auto &inputImage = args[0];
-    auto &blurAmount = args[1];
-    auto callOp = _builder.create<BlurOp>(_builder.getUnknownLoc(), imageType, inputImage, blurAmount);
-    return callOp.getResult();
   } else if (name == "save_image") {
     auto &inputImage = args[0];
     auto &filename = args[1];
@@ -202,6 +196,16 @@ mlir::Value MLIRGen::emitBuiltinCall(CallNode *node, const std::vector<mlir::Val
     auto &inputImage1 = args[0];
     auto &inputImage2 = args[1];
     auto callOp = _builder.create<DiffOp>(_builder.getUnknownLoc(), inputImage1.getType(), inputImage1, inputImage2);
+    return callOp.getResult();
+  } else if (name == "dilate") {
+    auto &inputImage = args[0];
+    auto &radius = args[1];
+    auto callOp = _builder.create<DilateOp>(_builder.getUnknownLoc(), inputImage.getType(), inputImage, radius);
+    return callOp.getResult();
+  } else if (name == "erode") {
+    auto &inputImage = args[0];
+    auto &radius = args[1];
+    auto callOp = _builder.create<ErodeOp>(_builder.getUnknownLoc(), inputImage.getType(), inputImage, radius);
     return callOp.getResult();
   } else {
     throw std::runtime_error("Unsupported builtin function: " + name);

--- a/src/ops.cpp
+++ b/src/ops.cpp
@@ -1,5 +1,45 @@
-#include "dialect.h"
 #include "ops.h"
+#include "types.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+
+#include <limits>
+
+namespace picceler {
+
+mlir::Value createFloatConstant(mlir::OpBuilder &builder, mlir::Location loc, double value) {
+  return builder.create<mlir::arith::ConstantFloatOp>(loc, builder.getF64Type(), llvm::APFloat(value));
+}
+
+std::pair<uint64_t, uint64_t> getKernelNeighborhoodSize(mlir::Value kernelOperand) {
+  if (auto kernelMemRefType = mlir::dyn_cast<mlir::MemRefType>(kernelOperand.getType())) {
+    if (kernelMemRefType.getRank() < 2) {
+      return {0, 0};
+    }
+
+    auto rows = kernelMemRefType.getShape()[0];
+    auto cols = kernelMemRefType.getShape()[1];
+    if (rows <= 0 || cols <= 0) {
+      return {0, 0};
+    }
+
+    return {static_cast<uint64_t>(rows), static_cast<uint64_t>(cols)};
+  }
+
+  if (auto kernelTypeAttr = mlir::dyn_cast<KernelType>(kernelOperand.getType())) {
+    auto rows = kernelTypeAttr.getRows();
+    auto cols = kernelTypeAttr.getCols();
+    if (rows <= 0 || cols <= 0) {
+      return {0, 0};
+    }
+
+    return {static_cast<uint64_t>(rows), static_cast<uint64_t>(cols)};
+  }
+
+  return {0, 0};
+}
+
+} // namespace picceler
 
 namespace picceler {
 
@@ -18,7 +58,115 @@ llvm::LogicalResult KernelConstOp::verify() {
   return mlir::success();
 }
 
+mlir::Value DilateOp::initializeAccumulator(mlir::OpBuilder &builder, mlir::Location loc) {
+  return createFloatConstant(builder, loc, -std::numeric_limits<double>::infinity());
+}
+
+mlir::Value DilateOp::accumulate(mlir::OpBuilder &builder, mlir::Location loc, mlir::Value currentAcc,
+                                 mlir::Value pixelValue, mlir::Value optionalKernelValue) {
+  auto img = pixelValue;
+  (void)img;
+  (void)optionalKernelValue;
+  return builder.create<mlir::arith::MaximumFOp>(loc, currentAcc, pixelValue).getResult();
+}
+
+mlir::Value DilateOp::finalizeAccumulator(mlir::OpBuilder &builder, mlir::Location loc, mlir::Value finalAcc) {
+  (void)builder;
+  (void)loc;
+  return finalAcc;
+}
+
+std::pair<uint64_t, uint64_t> DilateOp::getNeighborhoodSize(mlir::ArrayRef<mlir::Value> operands) {
+  if (operands.size() < 2) {
+    return {0, 0};
+  }
+
+  auto img = operands[0];
+  auto radiusOperand = operands[1];
+  (void)img;
+
+  auto constRadius = radiusOperand.getDefiningOp<mlir::arith::ConstantIntOp>();
+  if (!constRadius) {
+    return {0, 0};
+  }
+
+  auto neighborhoodSize = static_cast<uint64_t>(2 * constRadius.value() + 1);
+  return {neighborhoodSize, neighborhoodSize};
+}
+
+mlir::Value ErodeOp::initializeAccumulator(mlir::OpBuilder &builder, mlir::Location loc) {
+  return createFloatConstant(builder, loc, std::numeric_limits<double>::infinity());
+}
+
+mlir::Value ErodeOp::accumulate(mlir::OpBuilder &builder, mlir::Location loc, mlir::Value currentAcc,
+                                mlir::Value pixelValue, mlir::Value optionalKernelValue) {
+  auto img = pixelValue;
+  (void)img;
+  (void)optionalKernelValue;
+  return builder.create<mlir::arith::MinimumFOp>(loc, currentAcc, pixelValue).getResult();
+}
+
+mlir::Value ErodeOp::finalizeAccumulator(mlir::OpBuilder &builder, mlir::Location loc, mlir::Value finalAcc) {
+  (void)builder;
+  (void)loc;
+  return finalAcc;
+}
+
+std::pair<uint64_t, uint64_t> ErodeOp::getNeighborhoodSize(mlir::ArrayRef<mlir::Value> operands) {
+  if (operands.size() < 2) {
+    return {0, 0};
+  }
+
+  auto img = operands[0];
+  auto radiusOperand = operands[1];
+  (void)img;
+
+  auto constRadius = radiusOperand.getDefiningOp<mlir::arith::ConstantIntOp>();
+  if (!constRadius) {
+    return {0, 0};
+  }
+
+  auto neighborhoodSize = static_cast<uint64_t>(2 * constRadius.value() + 1);
+  return {neighborhoodSize, neighborhoodSize};
+}
+
+mlir::Value ConvolutionOp::initializeAccumulator(mlir::OpBuilder &builder, mlir::Location loc) {
+  return createFloatConstant(builder, loc, 0.0);
+}
+
+mlir::Value ConvolutionOp::accumulate(mlir::OpBuilder &builder, mlir::Location loc, mlir::Value currentAcc,
+                                      mlir::Value pixelValue, mlir::Value optionalKernelValue) {
+  auto img = pixelValue;
+  auto kernelWeight = optionalKernelValue;
+  (void)img;
+  return builder
+      .create<mlir::arith::AddFOp>(loc, currentAcc, builder.create<mlir::arith::MulFOp>(loc, pixelValue, kernelWeight))
+      .getResult();
+}
+
+mlir::Value ConvolutionOp::finalizeAccumulator(mlir::OpBuilder &builder, mlir::Location loc, mlir::Value finalAcc) {
+  (void)builder;
+  (void)loc;
+  return finalAcc;
+}
+
+std::pair<uint64_t, uint64_t> ConvolutionOp::getNeighborhoodSize(mlir::ArrayRef<mlir::Value> operands) {
+  if (operands.size() < 2) {
+    return {0, 0};
+  }
+
+  auto img = operands[0];
+  auto kernelOperand = operands[1];
+  (void)img;
+
+  return getKernelNeighborhoodSize(kernelOperand);
+}
+
 } // namespace picceler
+
+#define GET_OP_INTERFACE_DEFS
+#include "piccelerInterfaces.cpp.inc"
+#undef GET_OP_INTERFACE_DEFS
 
 #define GET_OP_CLASSES
 #include "piccelerOps.cpp.inc"

--- a/src/ops.cpp
+++ b/src/ops.cpp
@@ -39,10 +39,6 @@ std::pair<uint64_t, uint64_t> getKernelNeighborhoodSize(mlir::Value kernelOperan
   return {0, 0};
 }
 
-} // namespace picceler
-
-namespace picceler {
-
 llvm::LogicalResult KernelConstOp::verify() {
   auto valuesAttr = getValues();
   auto kernel = getResult().getType();
@@ -170,4 +166,4 @@ std::pair<uint64_t, uint64_t> ConvolutionOp::getNeighborhoodSize(mlir::ArrayRef<
 
 #define GET_OP_CLASSES
 #include "piccelerOps.cpp.inc"
-#define GET_OP_CLASSES
+#undef GET_OP_CLASSES

--- a/src/picceler_ops_to_func_calls_pass.cpp
+++ b/src/picceler_ops_to_func_calls_pass.cpp
@@ -115,33 +115,6 @@ struct SaveImageToCall : public mlir::OpRewritePattern<SaveImageOp> {
   }
 };
 
-/**
- * @brief Pattern to lower BlurOp to a function call.
- */
-struct BlurImageToCall : public mlir::OpRewritePattern<BlurOp> {
-  using mlir::OpRewritePattern<BlurOp>::OpRewritePattern;
-
-  mlir::LogicalResult matchAndRewrite(BlurOp op, mlir::PatternRewriter &rewriter) const override {
-
-    auto module = op->getParentOfType<mlir::ModuleOp>();
-    auto ctx = rewriter.getContext();
-    auto loc = op.getLoc();
-
-    auto stringType = StringType::get(ctx);
-    auto imageType = ImageType::get(ctx);
-
-    auto func = ensureRuntimeFunc(module, "piccelerBlurImage", {imageType, stringType}, {imageType}, rewriter, loc);
-    llvm::SmallVector<mlir::Value, 2> args;
-    args.push_back(op.getInput());
-    args.push_back(op.getMode());
-
-    auto call = rewriter.create<mlir::func::CallOp>(loc, func, args);
-    rewriter.replaceOp(op, call.getResults());
-
-    return mlir::success();
-  }
-};
-
 #define GEN_PASS_DEF_PICCELEROPSTOFUNCCALLS
 #include "piccelerPasses.h.inc"
 
@@ -152,7 +125,7 @@ struct PiccelerOpsToFuncCallsPass : public impl::PiccelerOpsToFuncCallsBase<Picc
     mlir::ModuleOp module = getOperation();
 
     mlir::RewritePatternSet patterns(&getContext());
-    patterns.add<LoadImageToCall, ShowImageToCall, SaveImageToCall, BlurImageToCall>(&getContext());
+    patterns.add<LoadImageToCall, ShowImageToCall, SaveImageToCall>(&getContext());
 
     if (mlir::failed(mlir::applyPatternsGreedily(module, std::move(patterns)))) {
       signalPassFailure();

--- a/src/picceler_to_affine_pass.cpp
+++ b/src/picceler_to_affine_pass.cpp
@@ -13,8 +13,6 @@
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/IR/BuiltinOps.h"
 
-#include <iostream>
-
 #include "ops.h"
 #include "types.h"
 #include "image_access_helper.h"
@@ -194,182 +192,6 @@ struct InvertToAffine : mlir::OpConversionPattern<InvertOp> {
     processChannel(3, false); // A
 
     rewriter.replaceOp(op, output);
-    return mlir::success();
-  }
-};
-
-struct ConvolutionToAffine : mlir::OpConversionPattern<ConvolutionOp> {
-  using OpConversionPattern::OpConversionPattern;
-
-  mlir::LogicalResult matchAndRewrite(ConvolutionOp op, ConvolutionOpAdaptor adaptor,
-                                      mlir::ConversionPatternRewriter &rewriter) const override {
-    auto ptrType = mlir::LLVM::LLVMPointerType::get(getContext());
-    auto indexType = rewriter.getIndexType();
-    auto i8Type = rewriter.getI8Type();
-    auto f64Type = rewriter.getF64Type();
-    auto i64Type = rewriter.getI64Type();
-
-    mlir::Location loc = op.getLoc();
-
-    mlir::Value input = adaptor.getInput();
-    if (input.getType() != ptrType) {
-      input = rewriter.create<mlir::UnrealizedConversionCastOp>(loc, ptrType, input).getResult(0);
-    }
-    mlir::Value kStack = adaptor.getKernel();
-
-    auto kMemTy = mlir::dyn_cast<mlir::MemRefType>(kStack.getType());
-
-    uint32_t rows = kMemTy.getShape()[0];
-    uint32_t cols = kMemTy.getShape()[1];
-
-    ImageAccessHelper inputImage(input, rewriter, loc);
-    mlir::Value inputWidthI32 = inputImage.getWidth();
-    mlir::Value inputHeightI32 = inputImage.getHeight();
-    mlir::Value inputDataPtr = inputImage.getDataPtr();
-
-    auto createCall = rewriter.create<mlir::func::CallOp>(loc, ptrType, "piccelerCreateImage",
-                                                          mlir::ValueRange{inputWidthI32, inputHeightI32});
-    mlir::Value output = createCall.getResult(0);
-
-    ImageAccessHelper outputImage(output, rewriter, loc);
-    mlir::Value outputDataPtr = outputImage.getDataPtr();
-
-    mlir::Value width = rewriter.create<mlir::arith::IndexCastOp>(loc, indexType, inputWidthI32);
-    mlir::Value height = rewriter.create<mlir::arith::IndexCastOp>(loc, indexType, inputHeightI32);
-
-    auto c0 = rewriter.create<mlir::arith::ConstantIndexOp>(loc, 0);
-
-    auto ubMap = mlir::AffineMap::get(1, 0, rewriter.getAffineDimExpr(0), rewriter.getContext());
-
-    auto oneConstant = rewriter.create<mlir::arith::ConstantIntOp>(loc, 1, 32);
-    auto sumR = rewriter.create<mlir::LLVM::AllocaOp>(loc, ptrType, f64Type, oneConstant);
-    auto sumG = rewriter.create<mlir::LLVM::AllocaOp>(loc, ptrType, f64Type, oneConstant);
-    auto sumB = rewriter.create<mlir::LLVM::AllocaOp>(loc, ptrType, f64Type, oneConstant);
-
-    auto rowLoop = rewriter.create<mlir::affine::AffineForOp>(loc, mlir::ValueRange{}, rewriter.getConstantAffineMap(0),
-                                                              height, ubMap, 1);
-    rewriter.setInsertionPointToStart(rowLoop.getBody());
-
-    auto pixelRowIndex = rowLoop.getInductionVar();
-    auto coolLoop = rewriter.create<mlir::affine::AffineForOp>(loc, mlir::ValueRange{},
-                                                               rewriter.getConstantAffineMap(0), width, ubMap, 1);
-    rewriter.setInsertionPointToStart(coolLoop.getBody());
-
-    auto c0_f32 = rewriter.create<mlir::arith::ConstantFloatOp>(loc, f64Type, llvm::APFloat(0.0));
-    rewriter.create<mlir::LLVM::StoreOp>(loc, c0_f32, sumR);
-    rewriter.create<mlir::LLVM::StoreOp>(loc, c0_f32, sumG);
-    rewriter.create<mlir::LLVM::StoreOp>(loc, c0_f32, sumB);
-
-    auto pixelColIndex = coolLoop.getInductionVar();
-
-    auto indexMap = mlir::AffineMap::get(
-        2, 1, (rewriter.getAffineDimExpr(0) * rewriter.getAffineSymbolExpr(0) + rewriter.getAffineDimExpr(1)) * 4);
-
-    mlir::Value pixelBaseIndex = rewriter.create<mlir::affine::AffineApplyOp>(
-        loc, indexMap, mlir::ValueRange{pixelRowIndex, pixelColIndex, width});
-
-    auto kRowLoop = rewriter.create<mlir::affine::AffineForOp>(loc, 0, rows);
-
-    rewriter.setInsertionPointToStart(kRowLoop.getBody());
-    auto kx = kRowLoop.getInductionVar();
-
-    auto kColLoop = rewriter.create<mlir::affine::AffineForOp>(loc, 0, cols);
-
-    rewriter.setInsertionPointToStart(kColLoop.getBody());
-    auto ky = kColLoop.getInductionVar();
-
-    // d0: AxisIndex, d1: kAxisIndex, s0: half-width
-    auto coordMap = mlir::AffineMap::get(
-        2, 1, rewriter.getAffineDimExpr(0) + rewriter.getAffineDimExpr(1) - rewriter.getAffineSymbolExpr(0));
-
-    mlir::Value rowOffset = rewriter.create<mlir::arith::ConstantIndexOp>(loc, rows / 2);
-    mlir::Value colOffset = rewriter.create<mlir::arith::ConstantIndexOp>(loc, cols / 2);
-
-    mlir::Value nRow =
-        rewriter.create<mlir::affine::AffineApplyOp>(loc, coordMap, mlir::ValueRange{pixelRowIndex, kx, rowOffset});
-    mlir::Value nCol =
-        rewriter.create<mlir::affine::AffineApplyOp>(loc, coordMap, mlir::ValueRange{pixelColIndex, ky, colOffset});
-
-    auto nPixelBaseIndex =
-        rewriter.create<mlir::affine::AffineApplyOp>(loc, indexMap, mlir::ValueRange{nRow, nCol, width});
-
-    auto rowLow = rewriter.create<mlir::arith::CmpIOp>(loc, mlir::arith::CmpIPredicate::sge, nRow, c0);
-    auto rowHigh = rewriter.create<mlir::arith::CmpIOp>(loc, mlir::arith::CmpIPredicate::slt, nRow, height);
-
-    auto colLow = rewriter.create<mlir::arith::CmpIOp>(loc, mlir::arith::CmpIPredicate::sge, nCol, c0);
-    auto colHigh = rewriter.create<mlir::arith::CmpIOp>(loc, mlir::arith::CmpIPredicate::slt, nCol, width);
-
-    auto rowValid = rewriter.create<mlir::arith::AndIOp>(loc, rowLow, rowHigh);
-    auto colValid = rewriter.create<mlir::arith::AndIOp>(loc, colLow, colHigh);
-    auto isValid = rewriter.create<mlir::arith::AndIOp>(loc, rowValid, colValid);
-
-    auto ifOp = rewriter.create<mlir::scf::IfOp>(loc, isValid.getResult(), false);
-
-    rewriter.setInsertionPointToStart(ifOp.thenBlock());
-
-    auto kWeight = rewriter.create<mlir::memref::LoadOp>(loc, kStack, mlir::ValueRange{kx, ky});
-
-    auto multiplyAndAccumulate = [&](int offset, mlir::Value sumAlloca, bool applyConvolution) {
-      auto cOffset = rewriter.create<mlir::arith::ConstantIndexOp>(loc, offset);
-      auto nByteAddr = rewriter.create<mlir::arith::AddIOp>(loc, nPixelBaseIndex, cOffset);
-      mlir::Value nByteAddrI64 = rewriter.create<mlir::arith::IndexCastOp>(loc, i64Type, nByteAddr);
-
-      auto ptr = rewriter.create<mlir::LLVM::GEPOp>(loc, ptrType, i8Type, inputDataPtr, mlir::ValueRange{nByteAddrI64});
-      auto byteVal = rewriter.create<mlir::LLVM::LoadOp>(loc, i8Type, ptr);
-      auto floatVal = rewriter.create<mlir::arith::UIToFPOp>(loc, f64Type, byteVal);
-
-      auto currentSum = rewriter.create<mlir::LLVM::LoadOp>(loc, f64Type, sumAlloca);
-      auto product = rewriter.create<mlir::arith::MulFOp>(loc, floatVal, kWeight);
-      auto nextSum = rewriter.create<mlir::arith::AddFOp>(loc, currentSum, product);
-      rewriter.create<mlir::LLVM::StoreOp>(loc, nextSum, sumAlloca);
-    };
-
-    multiplyAndAccumulate(0, sumR, true);
-    multiplyAndAccumulate(1, sumG, true);
-    multiplyAndAccumulate(2, sumB, true);
-
-    rewriter.setInsertionPointAfter(kRowLoop);
-
-    auto finalizePixel = [&](int offset, mlir::Value sumAlloca) {
-      auto finalSum = rewriter.create<mlir::LLVM::LoadOp>(loc, f64Type, sumAlloca);
-
-      auto c0_f64 = rewriter.create<mlir::arith::ConstantFloatOp>(loc, f64Type, llvm::APFloat(0.0));
-      auto c255_f64 = rewriter.create<mlir::arith::ConstantFloatOp>(loc, f64Type, llvm::APFloat(255.0));
-      auto clampedLow = rewriter.create<mlir::arith::MaximumFOp>(loc, finalSum, c0_f64);
-      auto clampedFinal = rewriter.create<mlir::arith::MinimumFOp>(loc, clampedLow, c255_f64);
-
-      auto byteVal = rewriter.create<mlir::arith::FPToUIOp>(loc, i8Type, clampedFinal);
-
-      auto cOffset = rewriter.create<mlir::arith::ConstantIndexOp>(loc, offset);
-      auto outAddr = rewriter.create<mlir::arith::AddIOp>(loc, pixelBaseIndex, cOffset);
-      auto outAddrI64 = rewriter.create<mlir::arith::IndexCastOp>(loc, i64Type, outAddr);
-
-      auto outPtr =
-          rewriter.create<mlir::LLVM::GEPOp>(loc, ptrType, i8Type, outputDataPtr, mlir::ValueRange{outAddrI64});
-
-      rewriter.create<mlir::LLVM::StoreOp>(loc, byteVal, outPtr);
-    };
-
-    finalizePixel(0, sumR);
-    finalizePixel(1, sumG);
-    finalizePixel(2, sumB);
-
-    // copy alpha channel
-    auto c3 = rewriter.create<mlir::arith::ConstantIndexOp>(loc, 3);
-    auto alphaAddr = rewriter.create<mlir::arith::AddIOp>(loc, pixelBaseIndex, c3);
-    auto alphaAddrI64 = rewriter.create<mlir::arith::IndexCastOp>(loc, i64Type, alphaAddr);
-
-    auto inAlphaPtr =
-        rewriter.create<mlir::LLVM::GEPOp>(loc, ptrType, i8Type, inputDataPtr, mlir::ValueRange{alphaAddrI64});
-    auto alphaVal = rewriter.create<mlir::LLVM::LoadOp>(loc, i8Type, inAlphaPtr);
-    auto outAlphaPtr =
-        rewriter.create<mlir::LLVM::GEPOp>(loc, ptrType, i8Type, outputDataPtr, mlir::ValueRange{alphaAddrI64});
-    rewriter.create<mlir::LLVM::StoreOp>(loc, alphaVal, outAlphaPtr);
-
-    rewriter.setInsertionPointAfter(rowLoop);
-
-    rewriter.replaceOp(op, output);
-
     return mlir::success();
   }
 };
@@ -622,6 +444,198 @@ struct DiffToAffine : mlir::OpConversionPattern<DiffOp> {
   }
 };
 
+struct NeighbourhoodOpsToAffine : mlir::OpInterfaceConversionPattern<NeighbourhoodOpInterface> {
+  using OpInterfaceConversionPattern::OpInterfaceConversionPattern;
+
+  mlir::LogicalResult matchAndRewrite(NeighbourhoodOpInterface op, mlir::ArrayRef<mlir::Value> operands,
+                                      mlir::ConversionPatternRewriter &rewriter) const override {
+    auto *rawOp = op.getOperation();
+    mlir::Location loc = rawOp->getLoc();
+
+    spdlog::info("Encountered neighbourhood operation: {}", rawOp->getName().getStringRef());
+
+    if (operands.empty()) {
+      rawOp->emitOpError("expected at least one operand");
+      return mlir::failure();
+    }
+
+    auto img = operands[0];
+    mlir::Value kernelOperand;
+    if (operands.size() > 1) {
+      kernelOperand = operands[1];
+    }
+
+    auto [neighborhoodRows, neighborhoodCols] = op.getNeighborhoodSize(operands);
+    if (neighborhoodRows == 0 || neighborhoodCols == 0) {
+      rawOp->emitOpError("unable to determine a valid neighborhood size");
+      return mlir::failure();
+    }
+
+    auto ptrType = mlir::LLVM::LLVMPointerType::get(getContext());
+    auto indexType = rewriter.getIndexType();
+    auto i8Type = rewriter.getI8Type();
+    auto f64Type = rewriter.getF64Type();
+    auto i64Type = rewriter.getI64Type();
+
+    mlir::Value input = img;
+    if (input.getType() != ptrType) {
+      input = rewriter.create<mlir::UnrealizedConversionCastOp>(loc, ptrType, input).getResult(0);
+    }
+
+    ImageAccessHelper inputImage(input, rewriter, loc);
+    mlir::Value inputWidthI32 = inputImage.getWidth();
+    mlir::Value inputHeightI32 = inputImage.getHeight();
+    mlir::Value inputDataPtr = inputImage.getDataPtr();
+
+    auto createCall = rewriter.create<mlir::func::CallOp>(loc, ptrType, "piccelerCreateImage",
+                                                          mlir::ValueRange{inputWidthI32, inputHeightI32});
+    mlir::Value output = createCall.getResult(0);
+
+    ImageAccessHelper outputImage(output, rewriter, loc);
+    mlir::Value outputDataPtr = outputImage.getDataPtr();
+
+    mlir::Value width = rewriter.create<mlir::arith::IndexCastOp>(loc, indexType, inputWidthI32);
+    mlir::Value height = rewriter.create<mlir::arith::IndexCastOp>(loc, indexType, inputHeightI32);
+
+    mlir::Value neighborhoodRowsValue =
+        rewriter.create<mlir::arith::ConstantIndexOp>(loc, static_cast<int64_t>(neighborhoodRows));
+    mlir::Value neighborhoodColsValue =
+        rewriter.create<mlir::arith::ConstantIndexOp>(loc, static_cast<int64_t>(neighborhoodCols));
+    mlir::Value neighborhoodRowRadiusValue =
+        rewriter.create<mlir::arith::ConstantIndexOp>(loc, static_cast<int64_t>(neighborhoodRows / 2));
+    mlir::Value neighborhoodColRadiusValue =
+        rewriter.create<mlir::arith::ConstantIndexOp>(loc, static_cast<int64_t>(neighborhoodCols / 2));
+    mlir::Value zeroIndex = rewriter.create<mlir::arith::ConstantIndexOp>(loc, 0);
+
+    auto oneConstant = rewriter.create<mlir::arith::ConstantIntOp>(loc, 1, 32);
+    auto sumR = rewriter.create<mlir::LLVM::AllocaOp>(loc, ptrType, f64Type, oneConstant);
+    auto sumG = rewriter.create<mlir::LLVM::AllocaOp>(loc, ptrType, f64Type, oneConstant);
+    auto sumB = rewriter.create<mlir::LLVM::AllocaOp>(loc, ptrType, f64Type, oneConstant);
+
+    auto rowLoop = rewriter.create<mlir::affine::AffineForOp>(
+        loc, mlir::ValueRange{}, rewriter.getConstantAffineMap(0), height,
+        mlir::AffineMap::get(1, 0, rewriter.getAffineDimExpr(0), rewriter.getContext()), 1);
+    rewriter.setInsertionPointToStart(rowLoop.getBody());
+
+    auto colLoop = rewriter.create<mlir::affine::AffineForOp>(
+        loc, mlir::ValueRange{}, rewriter.getConstantAffineMap(0), width,
+        mlir::AffineMap::get(1, 0, rewriter.getAffineDimExpr(0), rewriter.getContext()), 1);
+    rewriter.setInsertionPointToStart(colLoop.getBody());
+
+    mlir::Value pixelRowIndex = rowLoop.getInductionVar();
+    mlir::Value pixelColIndex = colLoop.getInductionVar();
+
+    auto indexMap = mlir::AffineMap::get(
+        2, 1, (rewriter.getAffineDimExpr(0) * rewriter.getAffineSymbolExpr(0) + rewriter.getAffineDimExpr(1)) * 4);
+
+    mlir::Value pixelBaseIndex = rewriter.create<mlir::affine::AffineApplyOp>(
+        loc, indexMap, mlir::ValueRange{pixelRowIndex, pixelColIndex, width});
+
+    mlir::Value initAcc = op.initializeAccumulator(rewriter, loc);
+    rewriter.create<mlir::LLVM::StoreOp>(loc, initAcc, sumR);
+    rewriter.create<mlir::LLVM::StoreOp>(loc, initAcc, sumG);
+    rewriter.create<mlir::LLVM::StoreOp>(loc, initAcc, sumB);
+
+    auto kRowLoop = rewriter.create<mlir::affine::AffineForOp>(
+        loc, mlir::ValueRange{}, rewriter.getConstantAffineMap(0), neighborhoodRowsValue,
+        mlir::AffineMap::get(1, 0, rewriter.getAffineDimExpr(0), rewriter.getContext()), 1);
+    rewriter.setInsertionPointToStart(kRowLoop.getBody());
+
+    auto kColLoop = rewriter.create<mlir::affine::AffineForOp>(
+        loc, mlir::ValueRange{}, rewriter.getConstantAffineMap(0), neighborhoodColsValue,
+        mlir::AffineMap::get(1, 0, rewriter.getAffineDimExpr(0), rewriter.getContext()), 1);
+    rewriter.setInsertionPointToStart(kColLoop.getBody());
+
+    mlir::Value kRowIndex = kRowLoop.getInductionVar();
+    mlir::Value kColIndex = kColLoop.getInductionVar();
+
+    auto coordMap = mlir::AffineMap::get(
+        2, 1, rewriter.getAffineDimExpr(0) + rewriter.getAffineDimExpr(1) - rewriter.getAffineSymbolExpr(0));
+
+    mlir::Value sampleRow = rewriter.create<mlir::affine::AffineApplyOp>(
+        loc, coordMap, mlir::ValueRange{pixelRowIndex, kRowIndex, neighborhoodRowRadiusValue});
+    mlir::Value sampleCol = rewriter.create<mlir::affine::AffineApplyOp>(
+        loc, coordMap, mlir::ValueRange{pixelColIndex, kColIndex, neighborhoodColRadiusValue});
+
+    auto rowLow = rewriter.create<mlir::arith::CmpIOp>(loc, mlir::arith::CmpIPredicate::sge, sampleRow, zeroIndex);
+    auto rowHigh = rewriter.create<mlir::arith::CmpIOp>(loc, mlir::arith::CmpIPredicate::slt, sampleRow, height);
+    auto colLow = rewriter.create<mlir::arith::CmpIOp>(loc, mlir::arith::CmpIPredicate::sge, sampleCol, zeroIndex);
+    auto colHigh = rewriter.create<mlir::arith::CmpIOp>(loc, mlir::arith::CmpIPredicate::slt, sampleCol, width);
+
+    auto rowValid = rewriter.create<mlir::arith::AndIOp>(loc, rowLow, rowHigh);
+    auto colValid = rewriter.create<mlir::arith::AndIOp>(loc, colLow, colHigh);
+    auto isValid = rewriter.create<mlir::arith::AndIOp>(loc, rowValid, colValid);
+
+    auto ifOp = rewriter.create<mlir::scf::IfOp>(loc, isValid.getResult(), false);
+    rewriter.setInsertionPointToStart(ifOp.thenBlock());
+
+    mlir::Value sampleBaseIndex =
+        rewriter.create<mlir::affine::AffineApplyOp>(loc, indexMap, mlir::ValueRange{sampleRow, sampleCol, width});
+
+    mlir::Value kernelWeight = rewriter.create<mlir::arith::ConstantFloatOp>(loc, f64Type, llvm::APFloat(1.0));
+    if (kernelOperand && mlir::isa<mlir::MemRefType>(kernelOperand.getType())) {
+      kernelWeight = rewriter.create<mlir::memref::LoadOp>(loc, kernelOperand, mlir::ValueRange{kRowIndex, kColIndex});
+    }
+
+    auto accumulateChannel = [&](int offset, mlir::Value sumAlloca) {
+      auto cOffset = rewriter.create<mlir::arith::ConstantIndexOp>(loc, offset);
+      auto byteAddr = rewriter.create<mlir::arith::AddIOp>(loc, sampleBaseIndex, cOffset);
+      auto byteAddrI64 = rewriter.create<mlir::arith::IndexCastOp>(loc, i64Type, byteAddr);
+
+      auto pixelPtr =
+          rewriter.create<mlir::LLVM::GEPOp>(loc, ptrType, i8Type, inputDataPtr, mlir::ValueRange{byteAddrI64});
+      auto pixelByte = rewriter.create<mlir::LLVM::LoadOp>(loc, i8Type, pixelPtr);
+      auto pixelAsF64 = rewriter.create<mlir::arith::UIToFPOp>(loc, f64Type, pixelByte);
+
+      auto currentAcc = rewriter.create<mlir::LLVM::LoadOp>(loc, f64Type, sumAlloca);
+      auto nextAcc = op.accumulate(rewriter, loc, currentAcc, pixelAsF64, kernelWeight);
+      rewriter.create<mlir::LLVM::StoreOp>(loc, nextAcc, sumAlloca);
+    };
+
+    accumulateChannel(0, sumR);
+    accumulateChannel(1, sumG);
+    accumulateChannel(2, sumB);
+
+    rewriter.setInsertionPointAfter(kRowLoop);
+
+    auto finalizeChannel = [&](int offset, mlir::Value sumAlloca) {
+      auto currentAcc = rewriter.create<mlir::LLVM::LoadOp>(loc, f64Type, sumAlloca);
+      auto finalizedAcc = op.finalizeAccumulator(rewriter, loc, currentAcc);
+
+      auto c0F64 = rewriter.create<mlir::arith::ConstantFloatOp>(loc, f64Type, llvm::APFloat(0.0));
+      auto c255F64 = rewriter.create<mlir::arith::ConstantFloatOp>(loc, f64Type, llvm::APFloat(255.0));
+      auto clampedLow = rewriter.create<mlir::arith::MaximumFOp>(loc, finalizedAcc, c0F64);
+      auto clampedHigh = rewriter.create<mlir::arith::MinimumFOp>(loc, clampedLow, c255F64);
+      auto byteVal = rewriter.create<mlir::arith::FPToUIOp>(loc, i8Type, clampedHigh);
+
+      auto cOffset = rewriter.create<mlir::arith::ConstantIndexOp>(loc, offset);
+      auto outAddr = rewriter.create<mlir::arith::AddIOp>(loc, pixelBaseIndex, cOffset);
+      auto outAddrI64 = rewriter.create<mlir::arith::IndexCastOp>(loc, i64Type, outAddr);
+      auto outPtr =
+          rewriter.create<mlir::LLVM::GEPOp>(loc, ptrType, i8Type, outputDataPtr, mlir::ValueRange{outAddrI64});
+      rewriter.create<mlir::LLVM::StoreOp>(loc, byteVal, outPtr);
+    };
+
+    finalizeChannel(0, sumR);
+    finalizeChannel(1, sumG);
+    finalizeChannel(2, sumB);
+
+    auto c3 = rewriter.create<mlir::arith::ConstantIndexOp>(loc, 3);
+    auto alphaAddr = rewriter.create<mlir::arith::AddIOp>(loc, pixelBaseIndex, c3);
+    auto alphaAddrI64 = rewriter.create<mlir::arith::IndexCastOp>(loc, i64Type, alphaAddr);
+    auto inputAlphaPtr =
+        rewriter.create<mlir::LLVM::GEPOp>(loc, ptrType, i8Type, inputDataPtr, mlir::ValueRange{alphaAddrI64});
+    auto alphaVal = rewriter.create<mlir::LLVM::LoadOp>(loc, i8Type, inputAlphaPtr);
+    auto outputAlphaPtr =
+        rewriter.create<mlir::LLVM::GEPOp>(loc, ptrType, i8Type, outputDataPtr, mlir::ValueRange{alphaAddrI64});
+    rewriter.create<mlir::LLVM::StoreOp>(loc, alphaVal, outputAlphaPtr);
+
+    rewriter.setInsertionPointAfter(rowLoop);
+    rewriter.replaceOp(rawOp, output);
+    return mlir::success();
+  }
+};
+
 #define GEN_PASS_DEF_PICCELERTOAFFINE
 #include "piccelerPasses.h.inc"
 
@@ -666,14 +680,14 @@ struct PiccelerToAffinePass : public impl::PiccelerToAffineBase<PiccelerToAffine
     target.addLegalOp<mlir::UnrealizedConversionCastOp>();
     target.addLegalOp<LoadImageOp, SaveImageOp, ShowImageOp, StringConstOp, KernelConstOp>();
     /*ConvolutionOp*/
-    target.addIllegalOp<BrightnessOp, InvertOp, RotateOp, DiffOp>();
+    target.addIllegalOp<BrightnessOp, InvertOp, RotateOp, DiffOp, ConvolutionOp, DilateOp, ErodeOp>();
 
     mlir::RewritePatternSet patterns(ctx);
     patterns.add<BrightnessToAffine>(typeConverter, ctx);
     patterns.add<InvertToAffine>(typeConverter, ctx);
-    patterns.add<ConvolutionToAffine>(typeConverter, ctx);
     patterns.add<RotateToAffine>(typeConverter, ctx);
     patterns.add<DiffToAffine>(typeConverter, ctx);
+    patterns.add<NeighbourhoodOpsToAffine>(typeConverter, ctx);
 
     if (mlir::failed(mlir::applyPartialConversion(module, target, std::move(patterns)))) {
       spdlog::error("Failed to convert Picceler operations to Affine dialect");

--- a/tablegen/CMakeLists.txt
+++ b/tablegen/CMakeLists.txt
@@ -4,6 +4,12 @@ mlir_tablegen(piccelerDialect.h.inc -gen-dialect-decls -dialect=picceler -I${CMA
 mlir_tablegen(piccelerDialect.cpp.inc -gen-dialect-defs -dialect=picceler -I${CMAKE_CURRENT_SOURCE_DIR})
 add_public_tablegen_target(PiccelerDialectIncGen)
 
+# Interfaces
+set(LLVM_TARGET_DEFINITIONS ${CMAKE_CURRENT_SOURCE_DIR}/interfaces.td)
+mlir_tablegen(piccelerInterfaces.h.inc -gen-op-interface-decls -dialect=picceler -I${CMAKE_CURRENT_SOURCE_DIR})
+mlir_tablegen(piccelerInterfaces.cpp.inc -gen-op-interface-defs -dialect=picceler -I${CMAKE_CURRENT_SOURCE_DIR})
+add_public_tablegen_target(PiccelerInterfacesIncGen)
+
 # Types
 set(LLVM_TARGET_DEFINITIONS ${CMAKE_CURRENT_SOURCE_DIR}/types.td)
 mlir_tablegen(piccelerTypes.h.inc -gen-typedef-decls -dialect=picceler -I${CMAKE_CURRENT_SOURCE_DIR})
@@ -26,5 +32,6 @@ set(PICCELER_TABLEGEN_TARGETS
   PiccelerTypesIncGen
   PiccelerOpsIncGen
   PiccelerPassesIncGen
+  PiccelerInterfacesIncGen
   PARENT_SCOPE
 )

--- a/tablegen/interfaces.td
+++ b/tablegen/interfaces.td
@@ -1,0 +1,49 @@
+// ===- interfaces.td - Picceler op interfaces -------------*- tablegen -*-===//
+//
+// This file defines shared interfaces for Picceler dialect ops.
+//
+// ===----------------------------------------------------------------------===//
+
+#ifndef PICCELER_INTERFACES_TD
+#define PICCELER_INTERFACES_TD
+
+include "mlir/IR/OpBase.td"
+
+def NeighbourhoodOpInterface : OpInterface<"NeighbourhoodOpInterface"> {
+	let description = [{
+		Interface for ops that lower through a neighborhood or sliding-window
+		reduction.
+	}];
+
+	let methods = [
+		InterfaceMethod<
+			"Returns the initial accumulator value for the reduction.",
+			"mlir::Value",
+			"initializeAccumulator",
+			(ins "mlir::OpBuilder &":$builder, "mlir::Location":$loc)
+		>,
+		InterfaceMethod<
+			"Updates the accumulator with one pixel sample and an optional kernel value.",
+			"mlir::Value",
+			"accumulate",
+			(ins "mlir::OpBuilder &":$builder, "mlir::Location":$loc,
+					 "mlir::Value":$currentAcc, "mlir::Value":$pixelValue,
+					 "mlir::Value":$optionalKernelValue)
+		>,
+		InterfaceMethod<
+			"Performs any final adjustment before the accumulated result is written out.",
+			"mlir::Value",
+			"finalizeAccumulator",
+			(ins "mlir::OpBuilder &":$builder, "mlir::Location":$loc,
+					 "mlir::Value":$finalAcc)
+		>,
+        InterfaceMethod<
+		"Returns the neighborhood shape to be processed around each pixel.",
+		"std::pair<uint64_t, uint64_t>",
+        "getNeighborhoodSize",
+        (ins "mlir::ArrayRef<mlir::Value>":$operands)
+        >
+	];
+}
+
+#endif

--- a/tablegen/ops.td
+++ b/tablegen/ops.td
@@ -9,6 +9,7 @@
 #define PICCELER_OPS_TD
 
 include "mlir/IR/OpBase.td"
+include "interfaces.td"
 include "types.td"
 
 def Picceler_StringConstOp : Op<PiccelerDialect, "string.const"> {
@@ -54,15 +55,9 @@ def Picceler_InvertOp : Op<PiccelerDialect, "invert", []> {
   let results = (outs Picceler_ImageType:$result);
 }
 
-def Picceler_ConvolutionOp : Op<PiccelerDialect, "convolution", []> {
+def Picceler_ConvolutionOp : Op<PiccelerDialect, "convolution", [NeighbourhoodOpInterface, DeclareOpInterfaceMethods<NeighbourhoodOpInterface, ["initializeAccumulator", "accumulate", "finalizeAccumulator", "getNeighborhoodSize"]>]> {
   let summary = "Apply convolution to an image with a kernel";
   let arguments = (ins Picceler_ImageType:$input, AnyTypeOf<[Picceler_KernelType, AnyMemRef]>:$kernel);
-  let results = (outs Picceler_ImageType:$result);
-}
-
-def Picceler_BlurOp : Op<PiccelerDialect, "blur", []> {
-  let summary = "Apply blur to an image";
-  let arguments = (ins Picceler_ImageType:$input, Picceler_StringType:$mode);
   let results = (outs Picceler_ImageType:$result);
 }
 
@@ -105,6 +100,18 @@ def Picceler_RotateOp : Op<PiccelerDialect, "rotate", []> {
 def Picceler_DiffOp : Op<PiccelerDialect, "diff", []> {
   let summary = "Compute the pixel-wise difference between two images";
   let arguments = (ins Picceler_ImageType:$input1, Picceler_ImageType:$input2);
+  let results = (outs Picceler_ImageType:$result);
+}
+
+def Picceler_ErodeOp : Op<PiccelerDialect, "erode", [NeighbourhoodOpInterface, DeclareOpInterfaceMethods<NeighbourhoodOpInterface, ["initializeAccumulator", "accumulate", "finalizeAccumulator", "getNeighborhoodSize"]>]> {
+  let summary = "Apply erosion to an image";
+  let arguments = (ins Picceler_ImageType:$input, I64:$radius);
+  let results = (outs Picceler_ImageType:$result);
+}
+
+def Picceler_DilateOp : Op<PiccelerDialect, "dilate", [NeighbourhoodOpInterface, DeclareOpInterfaceMethods<NeighbourhoodOpInterface, ["initializeAccumulator", "accumulate", "finalizeAccumulator", "getNeighborhoodSize"]>]> {
+  let summary = "Apply dilation to an image";
+  let arguments = (ins Picceler_ImageType:$input, I64:$radius);
   let results = (outs Picceler_ImageType:$result);
 }
 

--- a/tests/lit/mlir/picceler_to_affine_pass.mlir
+++ b/tests/lit/mlir/picceler_to_affine_pass.mlir
@@ -32,3 +32,57 @@ func.func @DiffImages(%arg0 : !picceler.image, %arg1 : !picceler.image) -> !picc
 // CHECK-NOT: "picceler.diff"       
 // CHECK: return
 
+// -----
+
+func.func @DilateImage(%arg0 : !picceler.image) -> !picceler.image {
+    %radius = "arith.constant"() {value = 1 : i64} : () -> i64
+    %0 = "picceler.dilate" (%arg0, %radius) : (!picceler.image, i64) -> !picceler.image
+    return %0 : !picceler.image
+}
+
+// CHECK-LABEL: func.func @DilateImage
+// CHECK: call @piccelerCreateImage
+// CHECK-COUNT-4: affine.for
+// CHECK: arith.maximumf
+// CHECK-NOT: "picceler.dilate"
+// CHECK: return
+
+// -----
+
+func.func @ErodeImage(%arg0 : !picceler.image) -> !picceler.image {
+    %radius = "arith.constant"() {value = 1 : i64} : () -> i64
+    %0 = "picceler.erode" (%arg0, %radius) : (!picceler.image, i64) -> !picceler.image
+    return %0 : !picceler.image
+}
+
+// CHECK-LABEL: func.func @ErodeImage
+// CHECK: call @piccelerCreateImage
+// CHECK-COUNT-4: affine.for
+// CHECK: arith.minimumf
+// CHECK-NOT: "picceler.erode"
+// CHECK: return
+
+// -----
+
+func.func @ConvolutionImage(%arg0 : !picceler.image) -> !picceler.image {
+    %c0 = "arith.constant"() {value = 0 : index} : () -> index
+    %c1 = "arith.constant"() {value = 1 : index} : () -> index
+    %c0f = "arith.constant"() {value = 0.0 : f64} : () -> f64
+    %kernel = memref.alloca() : memref<3x3xf64>
+    memref.store %c0f, %kernel[%c0, %c0] : memref<3x3xf64>
+    memref.store %c0f, %kernel[%c0, %c1] : memref<3x3xf64>
+    memref.store %c0f, %kernel[%c1, %c0] : memref<3x3xf64>
+    memref.store %c0f, %kernel[%c1, %c1] : memref<3x3xf64>
+    %0 = "picceler.convolution" (%arg0, %kernel) : (!picceler.image, memref<3x3xf64>) -> !picceler.image
+    return %0 : !picceler.image
+}
+
+// CHECK-LABEL: func.func @ConvolutionImage
+// CHECK: call @piccelerCreateImage
+// CHECK-COUNT-4: affine.for
+// CHECK: memref.load
+// CHECK: arith.mulf
+// CHECK: arith.addf
+// CHECK-NOT: "picceler.convolution"
+// CHECK: return
+


### PR DESCRIPTION
This PR was initially to add support for Dilate &/ Erode, for issues #29 #30. But I noticed the similar pattern between them and wanted something in common, also Convolution was very similar, as such I learnt about them being Neighbourhood-like ops, I've implemented an MLIR interface for them where they provide the necessary specialized information about them in order for a common 4D Loop Rewriter to exist for them.

Adds LIT lowering tests to affine, some more examples, removes unused unsupported BlurOp