### PR TITLE
Keyboard Input support for picceler

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,11 +1,10 @@
 HeaderFilterRegex: '.*picceler/.*'
+ExcludeHeaderFilterRegex: '.*/build/tablegen/.*'
 
-Checks: >
-  cppcoreguidelines-*
-  readability-identifier-naming
+Checks: 'cppcoreguidelines-*,readability-identifier-naming'
 
 CheckOptions:
-  - key:   readability-identifier-naming.ClassCase
+  - key: readability-identifier-naming.ClassCase
     value: CamelCase
-  - key:   readability-identifier-naming.FunctionCase
+  - key: readability-identifier-naming.FunctionCase
     value: camelBack

--- a/examples/read_input.pic
+++ b/examples/read_input.pic
@@ -1,0 +1,6 @@
+path = read_string("Please enter the path to your image:")
+value = read_number("Please enter the radius for DilateOp:")
+
+img = load_image(path)
+dilated_img = dilate(img, value)
+show_image(dilated_img)

--- a/include/ops.h
+++ b/include/ops.h
@@ -11,6 +11,7 @@
 #include <utility>
 
 #include "types.h"
+#include "error.h"
 #include "piccelerInterfaces.h.inc"
 
 #define GET_OP_CLASSES
@@ -27,5 +28,14 @@ namespace picceler {
  * @return An MLIR Value representing the constant float.
  */
 mlir::Value createFloatConstant(mlir::OpBuilder &builder, mlir::Location loc, double value);
+
+/**
+ * @brief Common utility function to create a constant int value in MLIR.
+ * @param builder The MLIR OpBuilder to use for creating the operation.
+ * @param loc The MLIR Location to associate with the operation.
+ * @param value The int64_t value to create as a constant.
+ * @return An MLIR Value representing the constant int.
+ */
+mlir::Value createIntConstant(mlir::OpBuilder &builder, mlir::Location loc, int64_t value);
 
 } // namespace picceler

--- a/lib/include/runtime.h
+++ b/lib/include/runtime.h
@@ -16,7 +16,7 @@ void piccelerShowImage(picceler::Image *image);
 void piccelerSaveImage(picceler::Image *image, const char *filename);
 picceler::Image *piccelerCreateImage(uint32_t width, uint32_t height);
 void *piccelerReadString(const char *prompt);
-void *piccelerReadNumber(const char *prompt);
+double piccelerReadNumber(const char *prompt);
 
 /**
  * \}

--- a/lib/include/runtime.h
+++ b/lib/include/runtime.h
@@ -15,6 +15,8 @@ picceler::Image *piccelerLoadImage(const char *filename);
 void piccelerShowImage(picceler::Image *image);
 void piccelerSaveImage(picceler::Image *image, const char *filename);
 picceler::Image *piccelerCreateImage(uint32_t width, uint32_t height);
+void *piccelerReadString(const char *prompt);
+void *piccelerReadNumber(const char *prompt);
 
 /**
  * \}

--- a/lib/src/runtime.cpp
+++ b/lib/src/runtime.cpp
@@ -9,31 +9,27 @@
 extern "C" {
 
 picceler::Image *piccelerLoadImage(const char *filename) {
-  std::cout << "piccelerLoadImage called with filename: " << filename << std::endl;
+  spdlog::debug("piccelerLoadImage called with filename: {}", filename);
   picceler::Image *imgPtr = picceler::loadImage(std::string(filename));
-  printf("Size: %zu, Width Off: %zu, Height Off: %zu, Data Off: %zu\n", sizeof(picceler::Image),
-         offsetof(picceler::Image, _width), offsetof(picceler::Image, _height), offsetof(picceler::Image, _data));
+  spdlog::debug("Size: {}, Width Off: {}, Height Off: {}, Data Off: {}", sizeof(picceler::Image),
+                offsetof(picceler::Image, _width), offsetof(picceler::Image, _height),
+                offsetof(picceler::Image, _data));
 
   return imgPtr;
 }
 
-picceler::Image piccelerBlurImage(picceler::Image image, const char *mode) {
-  std::cout << "piccelerBlurImage called with mode: " << mode << std::endl;
-  return image;
-}
-
 void piccelerShowImage(picceler::Image *image) {
-  std::cout << "piccelerShowImage called" << std::endl;
+  spdlog::debug("piccelerShowImage called");
   picceler::showImage(*image);
 }
 
 void piccelerSaveImage(picceler::Image *image, const char *filename) {
-  std::cout << "piccelerSaveImage called with filename: " << filename << std::endl;
+  spdlog::debug("piccelerSaveImage called with filename: {}", filename);
   picceler::saveImage(*image, std::string(filename));
 }
 
 picceler::Image *piccelerCreateImage(uint32_t width, uint32_t height) {
-  std::cout << "piccelerCreateImage called with " << width << " x " << height << std::endl;
+  spdlog::debug("piccelerCreateImage called with width: {}, height: {}", width, height);
   picceler::Image *newImage = new picceler::Image();
   newImage->_width = width;
   newImage->_height = height;
@@ -41,5 +37,23 @@ picceler::Image *piccelerCreateImage(uint32_t width, uint32_t height) {
   newImage->_data = new unsigned char[width * height * channels];
 
   return newImage;
+}
+
+void *piccelerReadString(const char *prompt) {
+  spdlog::debug("piccelerReadString called with prompt: {}", prompt);
+  std::string *result = new std::string(); // for now just let it leak
+
+  std::cout << prompt;
+  std::getline(std::cin, *result);
+  return static_cast<void *>(const_cast<char *>(result->c_str()));
+}
+
+void *piccelerReadNumber(const char *prompt) {
+  spdlog::debug("piccelerReadNumber called with prompt: {}", prompt);
+  double *result = new double(); // for now just let it leak
+
+  std::cout << prompt;
+  std::cin >> *result;
+  return static_cast<void *>(result);
 }
 }

--- a/lib/src/runtime.cpp
+++ b/lib/src/runtime.cpp
@@ -48,12 +48,14 @@ void *piccelerReadString(const char *prompt) {
   return static_cast<void *>(const_cast<char *>(result->c_str()));
 }
 
-void *piccelerReadNumber(const char *prompt) {
+double piccelerReadNumber(const char *prompt) {
   spdlog::debug("piccelerReadNumber called with prompt: {}", prompt);
   double *result = new double(); // for now just let it leak
 
   std::cout << prompt;
   std::cin >> *result;
-  return static_cast<void *>(result);
+  std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+  return *result;
 }
-}
+
+} // extern "C"

--- a/src/mlir_gen.cpp
+++ b/src/mlir_gen.cpp
@@ -8,6 +8,7 @@
 #include "spdlog/spdlog.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Dialect.h"
 
 #include "ops.h"
 #include "types.h"
@@ -57,8 +58,11 @@ mlir::Value coerceValueToInt64(mlir::OpBuilder &builder, mlir::Location loc, mli
     return builder.create<mlir::arith::ConstantIntOp>(loc, static_cast<int64_t>(numericValue), 64);
   }
 
-  // Anything else is not a literal, so we do not try to guess.
-  throw std::runtime_error(opName.str() + " requires " + argName.str() + " to be a literal integer value");
+  if (auto isRuntimeFloat = mlir::isa<mlir::FloatType>(value.getType())) {
+    return builder.create<mlir::arith::FPToSIOp>(loc, builder.getI64Type(), value);
+  }
+
+  throw std::runtime_error(opName.str() + " requires " + argName.str() + ", it is an unsupported use case");
 }
 
 MLIRGen::MLIRGen(mlir::MLIRContext *context)
@@ -277,6 +281,16 @@ mlir::Value MLIRGen::emitBuiltinCall(CallNode *node, const std::vector<mlir::Val
     auto &weight = args[2];
     auto callOp =
         _builder.create<BlendOp>(_builder.getUnknownLoc(), inputImage1.getType(), inputImage1, inputImage2, weight);
+    return callOp.getResult();
+  } else if (name == "read_number") {
+    auto resultType = _builder.getType<mlir::Float64Type>();
+    auto &prompt = args[0];
+    auto callOp = _builder.create<ReadNumberOp>(_builder.getUnknownLoc(), resultType, prompt);
+    return callOp.getResult();
+  } else if (name == "read_string") {
+    auto resultType = _builder.getType<StringType>();
+    auto &prompt = args[0];
+    auto callOp = _builder.create<ReadStringOp>(_builder.getUnknownLoc(), resultType, prompt);
     return callOp.getResult();
   } else {
     throw std::runtime_error("Unsupported builtin function: " + name);

--- a/src/ops.cpp
+++ b/src/ops.cpp
@@ -1,3 +1,5 @@
+
+#include "error.h"
 #include "ops.h"
 
 #define GET_OP_INTERFACE_DEFS

--- a/src/ops/common.cpp
+++ b/src/ops/common.cpp
@@ -6,4 +6,8 @@ mlir::Value createFloatConstant(mlir::OpBuilder &builder, mlir::Location loc, do
   return builder.create<mlir::arith::ConstantFloatOp>(loc, builder.getF64Type(), llvm::APFloat(value));
 }
 
+mlir::Value createIntConstant(mlir::OpBuilder &builder, mlir::Location loc, int64_t value) {
+  return builder.create<mlir::arith::ConstantIntOp>(loc, value, 64);
+}
+
 } // namespace picceler

--- a/src/ops/convolution.cpp
+++ b/src/ops/convolution.cpp
@@ -20,32 +20,33 @@ llvm::LogicalResult KernelConstOp::verify() {
   return mlir::success();
 }
 
-std::pair<uint64_t, uint64_t> getKernelNeighborhoodSize(mlir::Value kernelOperand) {
+Result<std::pair<mlir::Value, mlir::Value>> getKernelNeighborhoodSize(mlir::OpBuilder &builder, mlir::Location loc,
+                                                                      mlir::Value kernelOperand) {
   if (auto kernelMemRefType = mlir::dyn_cast<mlir::MemRefType>(kernelOperand.getType())) {
     if (kernelMemRefType.getRank() < 2) {
-      return {0, 0};
+      return std::unexpected(CompileError("Kernel operand must have rank of at least 2"));
     }
 
     auto rows = kernelMemRefType.getShape()[0];
     auto cols = kernelMemRefType.getShape()[1];
     if (rows <= 0 || cols <= 0) {
-      return {0, 0};
+      return std::unexpected(CompileError("Invalid kernel dimensions"));
     }
 
-    return {static_cast<uint64_t>(rows), static_cast<uint64_t>(cols)};
+    return std::make_pair(createIntConstant(builder, loc, rows), createIntConstant(builder, loc, cols));
   }
 
   if (auto kernelTypeAttr = mlir::dyn_cast<KernelType>(kernelOperand.getType())) {
     auto rows = kernelTypeAttr.getRows();
     auto cols = kernelTypeAttr.getCols();
     if (rows <= 0 || cols <= 0) {
-      return {0, 0};
+      return std::unexpected(CompileError("Invalid kernel dimensions"));
     }
 
-    return {static_cast<uint64_t>(rows), static_cast<uint64_t>(cols)};
+    return std::make_pair(createIntConstant(builder, loc, rows), createIntConstant(builder, loc, cols));
   }
 
-  return {0, 0};
+  return std::unexpected(CompileError("Invalid kernel operand"));
 }
 
 mlir::Value ConvolutionOp::initializeAccumulator(mlir::OpBuilder &builder, mlir::Location loc) {
@@ -54,30 +55,28 @@ mlir::Value ConvolutionOp::initializeAccumulator(mlir::OpBuilder &builder, mlir:
 
 mlir::Value ConvolutionOp::accumulate(mlir::OpBuilder &builder, mlir::Location loc, mlir::Value currentAcc,
                                       mlir::Value pixelValue, mlir::Value optionalKernelValue) {
-  auto img = pixelValue;
+
   auto kernelWeight = optionalKernelValue;
-  (void)img;
   return builder
       .create<mlir::arith::AddFOp>(loc, currentAcc, builder.create<mlir::arith::MulFOp>(loc, pixelValue, kernelWeight))
       .getResult();
 }
 
-mlir::Value ConvolutionOp::finalizeAccumulator(mlir::OpBuilder &builder, mlir::Location loc, mlir::Value finalAcc) {
-  (void)builder;
-  (void)loc;
+mlir::Value ConvolutionOp::finalizeAccumulator([[maybe_unused]] mlir::OpBuilder &builder,
+                                               [[maybe_unused]] mlir::Location loc, mlir::Value finalAcc) {
   return finalAcc;
 }
 
-std::pair<uint64_t, uint64_t> ConvolutionOp::getNeighborhoodSize(mlir::ArrayRef<mlir::Value> operands) {
+Result<std::pair<mlir::Value, mlir::Value>>
+ConvolutionOp::getNeighborhoodSize(mlir::OpBuilder &builder, mlir::Location loc, mlir::ArrayRef<mlir::Value> operands) {
   if (operands.size() < 2) {
-    return {0, 0};
+    return std::unexpected(CompileError("ConvolutionOp requires at least 2 operands: input image and kernel"));
   }
 
   [[maybe_unused]] auto img = operands[0];
   auto kernelOperand = operands[1];
-  (void)img;
 
-  return getKernelNeighborhoodSize(kernelOperand);
+  return getKernelNeighborhoodSize(builder, loc, kernelOperand);
 }
 
 } // namespace picceler

--- a/src/ops/dilate.cpp
+++ b/src/ops/dilate.cpp
@@ -1,6 +1,4 @@
 #include "ops.h"
-#include "types.h"
-
 #include "mlir/Dialect/Arith/IR/Arith.h"
 
 #include <limits>
@@ -25,22 +23,18 @@ mlir::Value DilateOp::finalizeAccumulator(mlir::OpBuilder &builder, mlir::Locati
   return finalAcc;
 }
 
-std::pair<uint64_t, uint64_t> DilateOp::getNeighborhoodSize(mlir::ArrayRef<mlir::Value> operands) {
+Result<std::pair<mlir::Value, mlir::Value>> DilateOp::getNeighborhoodSize(mlir::OpBuilder &builder, mlir::Location loc,
+                                                                          mlir::ArrayRef<mlir::Value> operands) {
   if (operands.size() < 2) {
-    return {0, 0};
+    return std::unexpected(CompileError("DilateOp requires at least 2 operands: input image and radius"));
   }
 
-  auto img = operands[0];
-  auto radiusOperand = operands[1];
-  (void)img;
+  [[maybe_unused]] auto img = operands[0];
+  auto radius = operands[1];
 
-  auto constRadius = radiusOperand.getDefiningOp<mlir::arith::ConstantIntOp>();
-  if (!constRadius) {
-    return {0, 0};
-  }
-
-  auto neighborhoodSize = static_cast<uint64_t>(2 * constRadius.value() + 1);
-  return {neighborhoodSize, neighborhoodSize};
+  auto doubleRadius = builder.create<mlir::arith::AddIOp>(loc, radius, radius);
+  auto neighborhoodSize = builder.create<mlir::arith::AddIOp>(loc, doubleRadius, createIntConstant(builder, loc, 1));
+  return std::make_pair(neighborhoodSize, neighborhoodSize);
 }
 
 } // namespace picceler

--- a/src/ops/erode.cpp
+++ b/src/ops/erode.cpp
@@ -24,22 +24,18 @@ mlir::Value ErodeOp::finalizeAccumulator(mlir::OpBuilder &builder, mlir::Locatio
   return finalAcc;
 }
 
-std::pair<uint64_t, uint64_t> ErodeOp::getNeighborhoodSize(mlir::ArrayRef<mlir::Value> operands) {
+Result<std::pair<mlir::Value, mlir::Value>> ErodeOp::getNeighborhoodSize(mlir::OpBuilder &builder, mlir::Location loc,
+                                                                         mlir::ArrayRef<mlir::Value> operands) {
   if (operands.size() < 2) {
-    return {0, 0};
+    return std::unexpected(CompileError("ErodeOp requires at least 2 operands: input image and radius"));
   }
 
-  auto img = operands[0];
-  auto radiusOperand = operands[1];
-  (void)img;
+  [[maybe_unused]] auto img = operands[0];
+  auto radius = operands[1];
 
-  auto constRadius = radiusOperand.getDefiningOp<mlir::arith::ConstantIntOp>();
-  if (!constRadius) {
-    return {0, 0};
-  }
-
-  auto neighborhoodSize = static_cast<uint64_t>(2 * constRadius.value() + 1);
-  return {neighborhoodSize, neighborhoodSize};
+  auto doubleRadius = builder.create<mlir::arith::AddIOp>(loc, radius, radius);
+  auto neighborhoodSize = builder.create<mlir::arith::AddIOp>(loc, doubleRadius, createIntConstant(builder, loc, 1));
+  return std::make_pair(neighborhoodSize, neighborhoodSize);
 }
 
 } // namespace picceler

--- a/src/picceler_ops_to_func_calls_pass.cpp
+++ b/src/picceler_ops_to_func_calls_pass.cpp
@@ -4,6 +4,7 @@
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Transforms/DialectConversion.h"
 #include "mlir/IR/SymbolTable.h"
 
 #include "ops.h"
@@ -40,10 +41,11 @@ mlir::func::FuncOp ensureRuntimeFunc(mlir::ModuleOp module, mlir::StringRef name
 /**
  * @brief Pattern to lower LoadImageOp to a function call.
  */
-struct LoadImageToCall : public mlir::OpRewritePattern<LoadImageOp> {
-  using mlir::OpRewritePattern<LoadImageOp>::OpRewritePattern;
+struct LoadImageToCall : public mlir::OpConversionPattern<LoadImageOp> {
+  using mlir::OpConversionPattern<LoadImageOp>::OpConversionPattern;
 
-  mlir::LogicalResult matchAndRewrite(LoadImageOp op, mlir::PatternRewriter &rewriter) const override {
+  mlir::LogicalResult matchAndRewrite(LoadImageOp op, LoadImageOpAdaptor adaptor,
+                                      mlir::ConversionPatternRewriter &rewriter) const override {
 
     auto module = op->getParentOfType<mlir::ModuleOp>();
     auto ctx = rewriter.getContext();
@@ -54,7 +56,7 @@ struct LoadImageToCall : public mlir::OpRewritePattern<LoadImageOp> {
 
     auto func = ensureRuntimeFunc(module, "piccelerLoadImage", {stringType}, {imageType}, rewriter, loc);
     llvm::SmallVector<mlir::Value, 1> args;
-    args.push_back(op.getFilename());
+    args.push_back(adaptor.getFilename());
 
     auto call = rewriter.create<mlir::func::CallOp>(loc, func, args);
     rewriter.replaceOp(op, call.getResults());
@@ -66,10 +68,11 @@ struct LoadImageToCall : public mlir::OpRewritePattern<LoadImageOp> {
 /**
  * @brief Pattern to lower ShowImageOp to a function call.
  */
-struct ShowImageToCall : public mlir::OpRewritePattern<ShowImageOp> {
-  using mlir::OpRewritePattern<ShowImageOp>::OpRewritePattern;
+struct ShowImageToCall : public mlir::OpConversionPattern<ShowImageOp> {
+  using mlir::OpConversionPattern<ShowImageOp>::OpConversionPattern;
 
-  mlir::LogicalResult matchAndRewrite(ShowImageOp op, mlir::PatternRewriter &rewriter) const override {
+  mlir::LogicalResult matchAndRewrite(ShowImageOp op, ShowImageOpAdaptor adaptor,
+                                      mlir::ConversionPatternRewriter &rewriter) const override {
 
     auto module = op->getParentOfType<mlir::ModuleOp>();
     auto ctx = rewriter.getContext();
@@ -79,7 +82,7 @@ struct ShowImageToCall : public mlir::OpRewritePattern<ShowImageOp> {
 
     auto func = ensureRuntimeFunc(module, "piccelerShowImage", {imageType}, {}, rewriter, loc);
     llvm::SmallVector<mlir::Value, 1> args;
-    args.push_back(op.getInput());
+    args.push_back(adaptor.getInput());
 
     auto call = rewriter.create<mlir::func::CallOp>(loc, func, args);
     rewriter.replaceOp(op, call.getResults());
@@ -91,10 +94,11 @@ struct ShowImageToCall : public mlir::OpRewritePattern<ShowImageOp> {
 /**
  * @brief Pattern to lower SaveImageOp to a function call.
  */
-struct SaveImageToCall : public mlir::OpRewritePattern<SaveImageOp> {
-  using mlir::OpRewritePattern<SaveImageOp>::OpRewritePattern;
+struct SaveImageToCall : public mlir::OpConversionPattern<SaveImageOp> {
+  using OpConversionPattern<SaveImageOp>::OpConversionPattern;
 
-  mlir::LogicalResult matchAndRewrite(SaveImageOp op, mlir::PatternRewriter &rewriter) const override {
+  mlir::LogicalResult matchAndRewrite(SaveImageOp op, SaveImageOpAdaptor adaptor,
+                                      mlir::ConversionPatternRewriter &rewriter) const override {
 
     auto module = op->getParentOfType<mlir::ModuleOp>();
     auto ctx = rewriter.getContext();
@@ -105,8 +109,53 @@ struct SaveImageToCall : public mlir::OpRewritePattern<SaveImageOp> {
 
     auto func = ensureRuntimeFunc(module, "piccelerSaveImage", {imageType, stringType}, {}, rewriter, loc);
     llvm::SmallVector<mlir::Value, 2> args;
-    args.push_back(op.getInput());
-    args.push_back(op.getFilename());
+    args.push_back(adaptor.getInput());
+    args.push_back(adaptor.getFilename());
+
+    auto call = rewriter.create<mlir::func::CallOp>(loc, func, args);
+    rewriter.replaceOp(op, call.getResults());
+
+    return mlir::success();
+  }
+};
+
+struct ReadNumberToCall : public mlir::OpConversionPattern<ReadNumberOp> {
+  using OpConversionPattern<ReadNumberOp>::OpConversionPattern;
+
+  mlir::LogicalResult matchAndRewrite(ReadNumberOp op, ReadNumberOpAdaptor adaptor,
+                                      mlir::ConversionPatternRewriter &rewriter) const override {
+    auto module = op->getParentOfType<mlir::ModuleOp>();
+    auto ctx = rewriter.getContext();
+    auto loc = op.getLoc();
+
+    auto stringType = StringType::get(ctx);
+    auto F64Type = rewriter.getF64Type();
+
+    auto func = ensureRuntimeFunc(module, "piccelerReadNumber", {stringType}, {F64Type}, rewriter, loc);
+    llvm::SmallVector<mlir::Value, 2> args;
+    args.push_back(adaptor.getPrompt());
+
+    auto call = rewriter.create<mlir::func::CallOp>(loc, func, args);
+    rewriter.replaceOp(op, call.getResults());
+
+    return mlir::success();
+  }
+};
+
+struct ReadStringToCall : mlir::OpConversionPattern<ReadStringOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  mlir::LogicalResult matchAndRewrite(ReadStringOp op, ReadStringOpAdaptor adaptor,
+                                      mlir::ConversionPatternRewriter &rewriter) const override {
+    auto module = op->getParentOfType<mlir::ModuleOp>();
+    auto ctx = rewriter.getContext();
+    auto loc = op.getLoc();
+
+    auto stringType = StringType::get(ctx);
+
+    auto func = ensureRuntimeFunc(module, "piccelerReadString", {stringType}, {stringType}, rewriter, loc);
+    llvm::SmallVector<mlir::Value, 2> args;
+    args.push_back(adaptor.getPrompt());
 
     auto call = rewriter.create<mlir::func::CallOp>(loc, func, args);
     rewriter.replaceOp(op, call.getResults());
@@ -127,10 +176,15 @@ struct PiccelerOpsToFuncCallsPass : public impl::PiccelerOpsToFuncCallsBase<Picc
   void runOnOperation() override {
     mlir::ModuleOp module = getOperation();
 
-    mlir::RewritePatternSet patterns(&getContext());
-    patterns.add<LoadImageToCall, ShowImageToCall, SaveImageToCall>(&getContext());
+    mlir::ConversionTarget target(getContext());
+    target.addLegalOp<mlir::ModuleOp>();
+    target.addLegalDialect<mlir::func::FuncDialect>();
+    target.addIllegalOp<LoadImageOp, ShowImageOp, SaveImageOp, ReadNumberOp, ReadStringOp>();
 
-    if (mlir::failed(mlir::applyPatternsGreedily(module, std::move(patterns)))) {
+    mlir::RewritePatternSet patterns(&getContext());
+    patterns.add<LoadImageToCall, ShowImageToCall, SaveImageToCall, ReadNumberToCall, ReadStringToCall>(&getContext());
+
+    if (mlir::failed(mlir::applyPartialConversion(module, target, std::move(patterns)))) {
       signalPassFailure();
     }
   }

--- a/src/picceler_to_affine_pass.cpp
+++ b/src/picceler_to_affine_pass.cpp
@@ -347,11 +347,13 @@ struct NeighbourhoodOpsToAffine : mlir::OpInterfaceConversionPattern<Neighbourho
       kernelOperand = operands[1];
     }
 
-    auto [neighborhoodRows, neighborhoodCols] = op.getNeighborhoodSize(operands);
-    if (neighborhoodRows == 0 || neighborhoodCols == 0) {
+    auto neighborhoodSizeResult = op.getNeighborhoodSize(rewriter, loc, operands);
+    if (!neighborhoodSizeResult) {
       rawOp->emitOpError("unable to determine a valid neighborhood size");
       return mlir::failure();
     }
+
+    auto [neighborhoodRows, neighborhoodCols] = *neighborhoodSizeResult;
 
     auto ptrType = mlir::LLVM::LLVMPointerType::get(getContext());
     auto indexType = rewriter.getIndexType();
@@ -379,14 +381,18 @@ struct NeighbourhoodOpsToAffine : mlir::OpInterfaceConversionPattern<Neighbourho
     mlir::Value width = rewriter.create<mlir::arith::IndexCastOp>(loc, indexType, inputWidthI32);
     mlir::Value height = rewriter.create<mlir::arith::IndexCastOp>(loc, indexType, inputHeightI32);
 
-    mlir::Value neighborhoodRowsValue =
-        rewriter.create<mlir::arith::ConstantIndexOp>(loc, static_cast<int64_t>(neighborhoodRows));
-    mlir::Value neighborhoodColsValue =
-        rewriter.create<mlir::arith::ConstantIndexOp>(loc, static_cast<int64_t>(neighborhoodCols));
-    mlir::Value neighborhoodRowRadiusValue =
-        rewriter.create<mlir::arith::ConstantIndexOp>(loc, static_cast<int64_t>(neighborhoodRows / 2));
-    mlir::Value neighborhoodColRadiusValue =
-        rewriter.create<mlir::arith::ConstantIndexOp>(loc, static_cast<int64_t>(neighborhoodCols / 2));
+    mlir::Value c2 = createIntConstant(rewriter, loc, 2);
+
+    mlir::Value neighborhoodRowRadius = rewriter.create<mlir::arith::DivSIOp>(loc, neighborhoodRows, c2);
+    mlir::Value neighborhoodColRadius = rewriter.create<mlir::arith::DivSIOp>(loc, neighborhoodCols, c2);
+
+    mlir::Value neighborhoodRowsIdx = rewriter.create<mlir::arith::IndexCastOp>(loc, indexType, neighborhoodRows);
+    mlir::Value neighborhoodColsIdx = rewriter.create<mlir::arith::IndexCastOp>(loc, indexType, neighborhoodCols);
+    mlir::Value neighborhoodRowRadiusIdx =
+        rewriter.create<mlir::arith::IndexCastOp>(loc, indexType, neighborhoodRowRadius);
+    mlir::Value neighborhoodColRadiusIdx =
+        rewriter.create<mlir::arith::IndexCastOp>(loc, indexType, neighborhoodColRadius);
+
     mlir::Value zeroIndex = rewriter.create<mlir::arith::ConstantIndexOp>(loc, 0);
 
     auto oneConstant = rewriter.create<mlir::arith::ConstantIntOp>(loc, 1, 32);
@@ -419,12 +425,12 @@ struct NeighbourhoodOpsToAffine : mlir::OpInterfaceConversionPattern<Neighbourho
     rewriter.create<mlir::LLVM::StoreOp>(loc, initAcc, sumB);
 
     auto kRowLoop = rewriter.create<mlir::affine::AffineForOp>(
-        loc, mlir::ValueRange{}, rewriter.getConstantAffineMap(0), neighborhoodRowsValue,
+        loc, mlir::ValueRange{}, rewriter.getConstantAffineMap(0), neighborhoodRowsIdx,
         mlir::AffineMap::get(1, 0, rewriter.getAffineDimExpr(0), rewriter.getContext()), 1);
     rewriter.setInsertionPointToStart(kRowLoop.getBody());
 
     auto kColLoop = rewriter.create<mlir::affine::AffineForOp>(
-        loc, mlir::ValueRange{}, rewriter.getConstantAffineMap(0), neighborhoodColsValue,
+        loc, mlir::ValueRange{}, rewriter.getConstantAffineMap(0), neighborhoodColsIdx,
         mlir::AffineMap::get(1, 0, rewriter.getAffineDimExpr(0), rewriter.getContext()), 1);
     rewriter.setInsertionPointToStart(kColLoop.getBody());
 
@@ -435,9 +441,9 @@ struct NeighbourhoodOpsToAffine : mlir::OpInterfaceConversionPattern<Neighbourho
         2, 1, rewriter.getAffineDimExpr(0) + rewriter.getAffineDimExpr(1) - rewriter.getAffineSymbolExpr(0));
 
     mlir::Value sampleRow = rewriter.create<mlir::affine::AffineApplyOp>(
-        loc, coordMap, mlir::ValueRange{pixelRowIndex, kRowIndex, neighborhoodRowRadiusValue});
+        loc, coordMap, mlir::ValueRange{pixelRowIndex, kRowIndex, neighborhoodRowRadiusIdx});
     mlir::Value sampleCol = rewriter.create<mlir::affine::AffineApplyOp>(
-        loc, coordMap, mlir::ValueRange{pixelColIndex, kColIndex, neighborhoodColRadiusValue});
+        loc, coordMap, mlir::ValueRange{pixelColIndex, kColIndex, neighborhoodColRadiusIdx});
 
     auto rowLow = rewriter.create<mlir::arith::CmpIOp>(loc, mlir::arith::CmpIPredicate::sge, sampleRow, zeroIndex);
     auto rowHigh = rewriter.create<mlir::arith::CmpIOp>(loc, mlir::arith::CmpIPredicate::slt, sampleRow, height);

--- a/tablegen/interfaces.td
+++ b/tablegen/interfaces.td
@@ -39,9 +39,9 @@ def NeighbourhoodOpInterface : OpInterface<"NeighbourhoodOpInterface"> {
 		>,
         InterfaceMethod<
 		"Returns the neighborhood shape to be processed around each pixel.",
-		"std::pair<uint64_t, uint64_t>",
+		"::picceler::Result<std::pair<mlir::Value, mlir::Value>>",
         "getNeighborhoodSize",
-        (ins "mlir::ArrayRef<mlir::Value>":$operands)
+        (ins "mlir::OpBuilder &":$builder, "mlir::Location":$loc, "mlir::ArrayRef<mlir::Value>":$operands)
         >
 	];
 }

--- a/tablegen/ops.td
+++ b/tablegen/ops.td
@@ -129,4 +129,26 @@ def Picceler_CropOp : Op<PiccelerDialect, "crop", []> {
   let results = (outs Picceler_ImageType:$result);
 }
 
+def Picceler_ReadStringOp : Op<PiccelerDialect, "read_string", []> {
+  let summary = "Read a string from the keyboard";
+  let arguments = (ins Picceler_StringType:$prompt);
+  let results = (outs Picceler_StringType:$result);
+}
+
+def Picceler_ReadNumberOp : Op<PiccelerDialect, "read_number", []> {
+  let summary = "Read a number from the keyboard";
+  let arguments = (ins Picceler_StringType:$prompt);
+  let results = (outs F64:$result);
+}
+
+def Picceler_PrintOp : Op<PiccelerDialect, "print", []> {
+  let summary = "Print anything to the console, alike std::format";
+  let arguments = (ins AnyType:$input);
+  let results = (outs);
+
+  // let hasVerifier = 1;
+}
+
+
+
 #endif

--- a/tests/lit/mlir/picceler_ops_to_func_calls_pass.mlir
+++ b/tests/lit/mlir/picceler_ops_to_func_calls_pass.mlir
@@ -50,3 +50,21 @@ func.func @LoadShowSaveImage() {
 // CHECK-NOT: "picceler.save_image"
 // CHECK-NEXT: call @piccelerSaveImage(%[[LOAD]], %[[OUTPATH]]) : (!picceler.image, !picceler.string) -> ()
 // CHECK-NEXT: return
+
+// -----
+
+func.func @ReadStringAndNumber() {
+    %0 = "picceler.string.const"() <{ value="Enter a string: " }> : () -> !picceler.string
+    %1 = "picceler.read_string"(%0) : (!picceler.string) -> !picceler.string
+    %2 = "picceler.string.const"() <{ value="Enter a number: " }> : () -> !picceler.string
+    %3 = "picceler.read_number"(%2) : (!picceler.string) -> f64
+    return
+}
+
+// CHECK-LABEL: func.func @ReadStringAndNumber()
+// CHECK-NEXT: %[[PROMPT1:.*]] = "picceler.string.const"() 
+// CHECK-NEXT: %[[READ_STR:.*]] = call @piccelerReadString(%[[PROMPT1]]) : (!picceler.string) -> !picceler.string
+// CHECK-NEXT: %[[PROMPT2:.*]] = "picceler.string.const"() 
+// CHECK-NEXT: %[[READ_NUM:.*]] = call @piccelerReadNumber(%[[PROMPT2]]) : (!picceler.string) -> f64
+// CHECK-NEXT: return
+


### PR DESCRIPTION
This PR will introduce support for reading from the keyboard, see `read_input.pic` for a clear example of this.

We currently support two functions, `read_string` and `read_number` both supporting a `(prompt)` argument. Also it removes a lot of code that used to verify that input to ops was constant, as this is no longer the case all the time, but some analysis in when compile time information is presented, that optimizations happen, should be conducted at some point in the future

Also added some QoL improvements to the code

This addresses the #52 issue