### PR TITLE
Replace clang++ system() call with direct ld.lld invocation via LLVM APIs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,6 @@ if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE)
 endif()
 
-find_package(CLI11 REQUIRED)
 find_package(spdlog REQUIRED)
 
 if (ENABLE_CLANG_TIDY)
@@ -63,11 +62,11 @@ include(AddLLVM)
 include(TableGen)
 include(AddMLIR)
 
-llvm_map_components_to_libnames(NATIVE_HW_LLVM_LIBS 
-    X86 
-    Target 
-    Core 
-    Support 
+llvm_map_components_to_libnames(NATIVE_HW_LLVM_LIBS
+    X86
+    Target
+    Core
+    Support
     AsmPrinter
 )
 

--- a/include/compiler.h
+++ b/include/compiler.h
@@ -2,8 +2,9 @@
 
 #include <format>
 #include <iostream>
+#include <memory>
 
-#include "CLI/CLI.hpp"
+#include "llvm/Support/CommandLine.h"
 #include "spdlog/spdlog.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -38,15 +39,20 @@ public:
   Compiler();
 
   /**
+   * @brief Parses command-line arguments.
+   * @return True if parsing was successful, false otherwise.
+   */
+  bool parseArgs(int argc, char **argv);
+
+  /**
    * @brief Runs the compilation process.
    */
   bool run();
 
-  CLI::App &getCliApp() { return _cliApp; }
   const CLIOptions &getCliOptions() const { return _cliOptions; }
 
 private:
-  mlir::MLIRContext &getContext() { return _context; }
+  mlir::MLIRContext &getContext();
 
   /**
    * @brief Initializes the MLIR dialect registry with the necessary dialects for the compiler.
@@ -71,13 +77,13 @@ private:
   bool linkWithLLD(const std::string &objFile, const std::string &runtimeLib, const std::string &outputExe);
 
 private:
-  CLI::App _cliApp;
   CLIOptions _cliOptions;
   Parser _parser;
 
-  mlir::MLIRContext _context;
-  MLIRGen _mlirGen;
-  IRPassManager _passManager;
+  // Lazily initialized to avoid LLVM option registration conflicts
+  std::unique_ptr<mlir::MLIRContext> _context;
+  std::unique_ptr<MLIRGen> _mlirGen;
+  std::unique_ptr<IRPassManager> _passManager;
 };
 
 } // namespace picceler

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 
-add_library(PiccelerGlobalDeps INTERFACE) 
+add_library(PiccelerGlobalDeps INTERFACE)
 
 target_include_directories(PiccelerGlobalDeps INTERFACE
     ${CMAKE_SOURCE_DIR}/include
@@ -9,7 +9,7 @@ target_include_directories(PiccelerGlobalDeps INTERFACE
     ${MLIR_INCLUDE_DIRS}
 )
 
-target_link_libraries(PiccelerGlobalDeps INTERFACE 
+target_link_libraries(PiccelerGlobalDeps INTERFACE
     spdlog::spdlog
 )
 
@@ -27,7 +27,7 @@ add_library(PiccelerFrontend STATIC
     parser.cpp
 )
 
-target_link_libraries(PiccelerFrontend PUBLIC 
+target_link_libraries(PiccelerFrontend PUBLIC
     PiccelerGlobalDeps
     PiccelerUtils
 )
@@ -49,7 +49,7 @@ target_link_libraries(PiccelerOps PUBLIC
     MLIRParser
 )
 
-add_dependencies(PiccelerOps 
+add_dependencies(PiccelerOps
     ${PICCELER_TABLEGEN_TARGETS}
 )
 
@@ -60,7 +60,7 @@ add_library(PiccelerIR STATIC
 )
 
 target_link_libraries(PiccelerIR PUBLIC
-    PiccelerGlobalDeps 
+    PiccelerGlobalDeps
     PiccelerFrontend
     PiccelerOps
     MLIRIR
@@ -76,7 +76,7 @@ add_library(PiccelerTransforms STATIC
     picceler_filters_to_conv_pass.cpp
 )
 
-target_link_libraries(PiccelerTransforms PUBLIC 
+target_link_libraries(PiccelerTransforms PUBLIC
     PiccelerIR
     MLIRPass
     MLIRTransforms
@@ -91,7 +91,7 @@ target_link_libraries(PiccelerTransforms PUBLIC
 )
 
 add_library(PiccelerSupport STATIC
-    image_access_helper.cpp 
+    image_access_helper.cpp
 )
 
 target_link_libraries(PiccelerSupport PUBLIC
@@ -104,7 +104,6 @@ add_library(PiccelerCore STATIC
 )
 
 target_link_libraries(PiccelerCore PUBLIC
-    CLI11::CLI11
     PiccelerFrontend
     PiccelerIR
     PiccelerTransforms
@@ -124,7 +123,7 @@ target_link_libraries(PiccelerCore PUBLIC
     ${NATIVE_HW_LLVM_LIBS}
 )
 
-add_executable(picceler 
+add_executable(picceler
     main.cpp
 )
 

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -23,22 +23,57 @@
 #include "llvm/MC/TargetRegistry.h"
 #include "llvm/IR/LegacyPassManager.h"
 #include "llvm/Target/TargetOptions.h"
+#include "llvm/Support/Path.h"
+#include "llvm/Support/Program.h"
 
 namespace picceler {
 
-Compiler::Compiler()
-    : _cliApp("picceler compiler"), _cliOptions(), _parser(), _context(initRegistry()), _mlirGen(&_context),
-      _passManager(&_context) {
-  spdlog::cfg::load_env_levels();
-  _cliApp.add_option("input_file", _cliOptions.inputFile, "Input source file")->required()->check(CLI::ExistingFile);
-  _cliApp.add_option("-o,--output", _cliOptions.outputFile, "Output executable file")->default_val("a.out");
+static llvm::cl::opt<std::string> InputFile(llvm::cl::Positional,
+    llvm::cl::desc("<input file>"), llvm::cl::Required);
 
-  _context.loadAllAvailableDialects();
-  spdlog::debug("Initialized MLIR Dialects:");
-  for (auto *dialect : _context.getLoadedDialects()) {
-    spdlog::debug(" - {}", dialect->getNamespace());
-  }
+static llvm::cl::opt<std::string> OutputFile("o",
+    llvm::cl::desc("Output executable file"),
+    llvm::cl::value_desc("filename"),
+    llvm::cl::init("a.out"));
+
+Compiler::Compiler()
+    : _cliOptions(), _parser(), _context(nullptr), _mlirGen(nullptr), _passManager(nullptr) {
+  spdlog::cfg::load_env_levels();
 }
+
+bool Compiler::parseArgs(int argc, char **argv) {
+  llvm::cl::ParseCommandLineOptions(argc, argv, "Picceler compiler\n");
+  _cliOptions.inputFile = InputFile;
+  _cliOptions.outputFile = OutputFile;
+
+  // Validate input file exists
+  if (!llvm::sys::fs::exists(_cliOptions.inputFile)) {
+    spdlog::error("Input file does not exist: {}", _cliOptions.inputFile);
+    return false;
+  }
+
+  return true;
+}
+
+mlir::MLIRContext &Compiler::getContext() {
+  // Lazy initialization: only create MLIR context after CLI parsing is complete.
+  // This avoids conflicts between CLI11 and LLVM's global command-line infrastructure.
+  if (!_context) {
+    auto registry = initRegistry();
+    _context = std::make_unique<mlir::MLIRContext>(registry);
+    _mlirGen = std::make_unique<MLIRGen>(_context.get());
+    _passManager = std::make_unique<IRPassManager>(_context.get());
+
+    _context->loadAllAvailableDialects();
+    spdlog::debug("Initialized MLIR Dialects:");
+    for (auto *dialect : _context->getLoadedDialects()) {
+      spdlog::debug(" - {}", dialect->getNamespace());
+    }
+  }
+  return *_context;
+}
+
+static std::string findRuntimeLibrary();
 
 mlir::DialectRegistry Compiler::initRegistry() {
   mlir::DialectRegistry registry;
@@ -55,6 +90,9 @@ mlir::DialectRegistry Compiler::initRegistry() {
 }
 
 bool Compiler::run() {
+  // Ensure MLIR context is initialized before proceeding
+  getContext();
+
   auto &cliOptions = getCliOptions();
   const auto &inputFile = _cliOptions.inputFile;
   const auto &outputFile = _cliOptions.outputFile;
@@ -89,11 +127,11 @@ bool Compiler::run() {
   _parser.printAST(ast.value());
 
   spdlog::info("Generating initial MLIR");
-  auto module = _mlirGen.generate(ast.value().get());
+  auto module = _mlirGen->generate(ast.value().get());
   spdlog::info("Finished generating initial MLIR");
   module->dump();
   spdlog::info("Running pass manager");
-  _passManager.run(module);
+  _passManager->run(module);
   spdlog::info("Finished running pass manager");
 
   llvm::LLVMContext llvmContext;
@@ -110,7 +148,17 @@ bool Compiler::run() {
     return false;
   }
 
-  success = linkWithLLD("picceler.o", "lib/libPiccelerRuntime.a", outputFile);
+  const std::string runtimeLib = findRuntimeLibrary();
+  if (runtimeLib.empty()) {
+    spdlog::error("Compiler Error: Picceler runtime library could not be found. Expected one of:");
+    spdlog::error("  build/lib/libPiccelerRuntime.a");
+    spdlog::error("  lib/libPiccelerRuntime.a");
+    spdlog::error("  ../build/lib/libPiccelerRuntime.a");
+    spdlog::error("  ../lib/libPiccelerRuntime.a");
+    return false;
+  }
+
+  success = linkWithLLD("picceler.o", runtimeLib, outputFile);
   if (!success) {
     spdlog::error("Failed to link an executable");
     return false;
@@ -156,18 +204,150 @@ bool Compiler::emitObjectFile(llvm::Module *llvmModule, const std::string &objFi
   return true;
 }
 
-bool Compiler::linkWithLLD(const std::string &objFile, const std::string &runtimeLib, const std::string &outputExe) {
-  // Build the link command using clang++ with -no-pie to avoid PIE relocations
-  std::string cmd =
-      "clang++ " + objFile + " " + runtimeLib + " -o " + outputExe + " -no-pie $(pkg-config --libs opencv4)";
-  spdlog::debug("Linking with command: {}", cmd);
+std::string findGccLibDir() {
+  std::error_code EC;
+  std::string basePath = "/usr/lib/gcc/x86_64-pc-linux-gnu";
+  if (!llvm::sys::fs::exists(basePath)) return "";
 
-  int ret = std::system(cmd.c_str());
-  if (ret == 0) {
+  std::string latestVersion = "";
+  for (llvm::sys::fs::directory_iterator dir(basePath, EC), end; !EC && dir != end; dir.increment(EC)) {
+      llvm::StringRef filename = llvm::sys::path::filename(dir->path());
+      if (filename.str() > latestVersion) {
+          latestVersion = filename.str();
+      }
+  }
+  return latestVersion.empty() ? "" : basePath + "/" + latestVersion;
+}
+
+static std::string findRuntimeLibrary() {
+  llvm::SmallString<256> cwd;
+  if (auto ec = llvm::sys::fs::current_path(cwd)) {
+    spdlog::warn("Unable to determine current working directory: {}", ec.message());
+    return "";
+  }
+
+  std::vector<llvm::SmallString<256>> candidates;
+  candidates.emplace_back(cwd);
+  llvm::sys::path::append(candidates.back(), "build");
+  llvm::sys::path::append(candidates.back(), "lib");
+  llvm::sys::path::append(candidates.back(), "libPiccelerRuntime.a");
+
+  candidates.emplace_back(cwd);
+  llvm::sys::path::append(candidates.back(), "lib");
+  llvm::sys::path::append(candidates.back(), "libPiccelerRuntime.a");
+
+  candidates.emplace_back(cwd);
+  llvm::sys::path::append(candidates.back(), "..", "build");
+  llvm::sys::path::append(candidates.back(), "lib");
+  llvm::sys::path::append(candidates.back(), "libPiccelerRuntime.a");
+
+  candidates.emplace_back(cwd);
+  llvm::sys::path::append(candidates.back(), "..", "lib");
+  llvm::sys::path::append(candidates.back(), "libPiccelerRuntime.a");
+
+  candidates.emplace_back(cwd);
+  llvm::sys::path::append(candidates.back(), "..", "..", "build");
+  llvm::sys::path::append(candidates.back(), "lib");
+  llvm::sys::path::append(candidates.back(), "libPiccelerRuntime.a");
+
+  for (const auto &candidate : candidates) {
+    if (llvm::sys::fs::exists(candidate)) {
+      return candidate.str().str();
+    }
+  }
+
+  return "";
+}
+
+bool Compiler::linkWithLLD(const std::string &objFile, const std::string &runtimeLib, const std::string &outputExe) {
+  spdlog::info("Starting linking for {}", outputExe);
+
+  if (!llvm::sys::fs::exists(objFile)) {
+    spdlog::error("Compiler Error: Generated object file not found at {}", objFile);
+    return false;
+  }
+
+  if (!llvm::sys::fs::exists(runtimeLib)) {
+    spdlog::error("Compiler Error: Picceler runtime library missing at {}", runtimeLib);
+    return false;
+  }
+
+  std::string gccLibDir = findGccLibDir();
+  if (gccLibDir.empty()) {
+    spdlog::warn("Could not dynamically find GCC lib directory. C++ global constructors/destructors might fail.");
+  }
+
+  std::vector<std::string> argsStr = {
+    "ld.lld",
+    "--dynamic-linker", "/lib64/ld-linux-x86-64.so.2",
+    "-o", outputExe,
+
+    "/usr/lib/Scrt1.o",
+    "/usr/lib/crti.o",
+    gccLibDir.empty() ? "" : gccLibDir + "/crtbeginS.o",
+
+    objFile,
+    runtimeLib,
+
+    "-L/usr/lib",
+    "-L/usr/local/lib",
+    "-lopencv_core",
+    "-lopencv_imgproc",
+    "-lopencv_highgui",
+    "-lopencv_imgcodecs",
+    "-lfmt",
+
+    "-lstdc++",
+    "-lm",
+    gccLibDir.empty() ? "" : "-L" + gccLibDir,
+    "-lgcc_s",
+    "-lgcc",
+    "-lc",
+
+    gccLibDir.empty() ? "" : gccLibDir + "/crtendS.o",
+    "/usr/lib/crtn.o"
+  };
+
+  // Find ld.lld in the environment rather than hardcoding its path.
+  auto lldPath = llvm::sys::findProgramByName("ld.lld");
+  if (!lldPath) {
+    spdlog::error("Could not find ld.lld in PATH. Install LLD or add it to PATH.");
+    return false;
+  }
+
+  // Filter out empty strings and convert to StringRef
+  std::vector<llvm::StringRef> args;
+  for (const auto& arg : argsStr) {
+      if (!arg.empty()) {
+          args.push_back(llvm::StringRef(arg));
+      }
+  }
+
+  spdlog::debug("Invoking linker with {} arguments", args.size());
+
+  // Use LLVM's ExecuteAndWait to invoke the system ld.lld linker.
+  // This avoids std::system() and keeps the linkage invocation inside LLVM tooling.
+  int result = llvm::sys::ExecuteAndWait(
+    *lldPath,
+    args,
+    std::nullopt,  // Use current environment
+    {},            // No redirects; inherit stdout/stderr
+    0,             // No timeout
+    0              // No memory limit
+  );
+
+  if (result == 0) {
     spdlog::info("Successfully linked executable: {}", outputExe);
     return true;
   } else {
-    spdlog::error("Linking failed with exit code: {}", ret);
+    spdlog::error("Linker phase failed with exit code: {}", result);
+
+    if (result == 127) {
+      spdlog::error("Diagnostic: ld.lld not found at /usr/bin/ld.lld. Check your LLD installation.");
+    } else {
+      spdlog::error("Diagnostic: Check linker error messages above for details.");
+    }
+
     return false;
   }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,13 +1,21 @@
 #include <vector>
 
-#include "CLI/CLI.hpp"
 #include "spdlog/spdlog.h"
 
 #include "compiler.h"
 
 int main(int argc, char **argv) {
   picceler::Compiler compiler;
-  CLI11_PARSE(compiler.getCliApp(), argc, argv);
 
-  compiler.run();
+  if (!compiler.parseArgs(argc, argv)) {
+    spdlog::error("Failed to parse command-line arguments");
+    return 1;
+  }
+
+  if (!compiler.run()) {
+    spdlog::error("Compilation failed");
+    return 1;
+  }
+
+  return 0;
 }


### PR DESCRIPTION
Replace fragile `clang++`/`system()` subprocess linking with direct `ld.lld` invocation via `llvm::sys::ExecuteAndWait`. Migrate CLI parsing from CLI11 to LLVM's command-line parser with lazy MLIR context initialization to avoid global option registration conflicts. Add robust runtime library and GCC directory discovery.

This addresses the #55 issue.