### PR TITLE
Adding support for User defined functions

### DIFF
--- a/examples/convolution.pic
+++ b/examples/convolution.pic
@@ -6,4 +6,6 @@ convolution_img = convolution(img, kernel)
 show_image(img)
 
 show_image(convolution_img)
+a = brightness(convolution_img, 128)
+show_image(a)
 save_image(convolution_img, "testme.png")

--- a/examples/function.pic
+++ b/examples/function.pic
@@ -1,11 +1,15 @@
 def f() {
-    img = load_image("~/Pictures/cat.png")
+    pathx = "~/Pictures/cat.png"
+    img = load_image(pathx)
     show_image(img)
+    g(pathx)
+    dilated = dilate(img, 3)
+    show_image(dilated)
 }
 
 def g(path : string)
 {
-    img = load_image("~/Pictures/cat.png")
+    img = load_image(path)
     show_image(img)
 }
 

--- a/examples/function.pic
+++ b/examples/function.pic
@@ -1,0 +1,12 @@
+def f() {
+    img = load_image("~/Pictures/cat.png")
+    show_image(img)
+}
+
+def g(path : string)
+{
+    img = load_image("~/Pictures/cat.png")
+    show_image(img)
+}
+
+f()

--- a/examples/function.pic
+++ b/examples/function.pic
@@ -2,14 +2,13 @@ def f() {
     pathx = "~/Pictures/cat.png"
     img = load_image(pathx)
     show_image(img)
-    g(pathx)
     dilated = dilate(img, 3)
     show_image(dilated)
 }
 
 def g(path : string)
 {
-    img = load_image(path)
+    img = load_image("~/Pictures/cat.png")
     show_image(img)
 }
 

--- a/include/ast.h
+++ b/include/ast.h
@@ -33,6 +33,9 @@ struct ModuleNode : public ASTNode {
   std::string toString() const override;
 };
 
+/**
+ * @brief AST node for function definitions.
+ */
 struct FunctionNode : public ASTNode {
   std::string name;
   std::vector<std::pair<std::string, std::string>> parameters;

--- a/include/ast.h
+++ b/include/ast.h
@@ -2,8 +2,7 @@
 
 #include <vector>
 #include <string>
-#include <cstddef>
-#include <cstdint>
+#include <optional>
 #include <memory>
 
 #include "lexer.h"
@@ -34,11 +33,19 @@ struct ModuleNode : public ASTNode {
   std::string toString() const override;
 };
 
+struct FunctionNode : public ASTNode {
+  std::string name;
+  std::vector<std::pair<std::string, std::string>> parameters;
+  std::vector<std::unique_ptr<ASTNode>> body;
+  std::string toString() const override;
+};
+
 /**
  * @brief AST node for variable references.
  */
 struct VariableNode : public ASTNode {
   std::string name;
+  std::optional<std::string> type; // optional type annotation
   std::string toString() const override;
 };
 

--- a/include/lexer.h
+++ b/include/lexer.h
@@ -194,9 +194,9 @@ private:
   Result<Token::Type> isType(const std::string &value) const;
 
   /**
-   * @brief Reads an identifier or keyword token from the input.
+   * @brief Reads an identifier, keyword or type token from the input.
    * @param start The starting line and column of the token.
-   * @return The identifier or keyword token.
+   * @return The identifier, keyword or type token.
    */
   Result<Token> readIdentifierOrKeywordOrType(std::pair<size_t, size_t> start);
 

--- a/include/lexer.h
+++ b/include/lexer.h
@@ -180,9 +180,9 @@ private:
   /*
    * @brief Identifies if a string is a keyword.
    * @param value The string to check.
-   * @return True if the string is a keyword, false otherwise.
+   * @return The token type if the string is a keyword, std::unexpected otherwise.
    */
-  bool isKeyword(const std::string &value) const;
+  Result<Token::Type> isKeyword(const std::string &value) const;
 
   /**
    * @brief Reads an identifier or keyword token from the input.

--- a/include/lexer.h
+++ b/include/lexer.h
@@ -26,7 +26,52 @@ namespace picceler {
  */
 struct Token {
   /** @brief The type of the token. */
-  enum class Type : size_t { IDENTIFIER, NUMBER, STRING, SYMBOL, EOF_TOKEN, UNKNOWN };
+  enum class Type : size_t {
+    IDENTIFIER, // Represents identifiers (user defined names)
+    NUMBER,     // Represents numeric literals (e.g., integers, floats)
+    STRING,     // Represents string literals
+    L_PAREN,    // Represents the left parenthesis '('
+    R_PAREN,    // Represents the right parenthesis ')'
+    L_BRACKET,  // Represents the left bracket '['
+    R_BRACKET,  // Represents the right bracket ']'
+    L_BRACE,    // Represents the left brace '{'
+    R_BRACE,    // Represents the right brace '}'
+    COMMA,      // Represents the comma ','
+    COLON,      // Represents the colon ':'
+    ARROW,      // Represents the arrow '->'
+    ASSIGN,     // Represents the assignment operator '='
+    KW_DEF,     // Represents the keyword 'def'
+    KW_RETURN,  // Represents the keyword 'return'
+    EOF_TOKEN,  // Represents the end of file
+    UNKNOWN     // Represents unknown tokens
+  };
+
+  Token() : _type(Type::UNKNOWN), _value(""), _line(0), _column(0) {}
+
+  Token(Type type, std::string value, size_t line, size_t column)
+      : _type(type), _value(std::move(value)), _line(line), _column(column) {}
+
+  Token(const Token &other) : _type(other._type), _value(other._value), _line(other._line), _column(other._column) {}
+  Token(Token &&other) noexcept
+      : _type(other._type), _value(std::move(other._value)), _line(other._line), _column(other._column) {}
+  Token &operator=(const Token &other) {
+    if (this != &other) {
+      _type = other._type;
+      _value = other._value;
+      _line = other._line;
+      _column = other._column;
+    }
+    return *this;
+  }
+  Token &operator=(Token &&other) noexcept {
+    if (this != &other) {
+      _type = other._type;
+      _value = std::move(other._value);
+      _line = other._line;
+      _column = other._column;
+    }
+    return *this;
+  }
 
   /**
    * @brief Converts the token type to a string representation.
@@ -42,6 +87,20 @@ struct Token {
     return std::format("Token(type: {}, value: '{}', line: {}, column: {})", typeToString(), _value, _line, _column);
   }
 
+  Type type() const { return _type; }
+  const std::string &value() const { return _value; }
+  size_t line() const { return _line; }
+  size_t column() const { return _column; }
+
+  /*
+   * @brief Compares a token to a token type for easy checking in parsing.
+   * @param lhs The token to compare.
+   * @param rhs The token type to compare against.
+   * @return True if the token's type matches the token type, false otherwise.
+   */
+  friend constexpr bool operator==(const Token &lhs, const Token::Type &rhs) { return lhs._type == rhs; }
+
+private:
   Type _type;
   std::string _value;
   size_t _line;
@@ -118,12 +177,19 @@ private:
    */
   bool isSymbol(char ch) const;
 
-  /**
-   * @brief Reads an identifier token from the input.
-   * @param start The starting line and column of the token.
-   * @return The identifier token.
+  /*
+   * @brief Identifies if a string is a keyword.
+   * @param value The string to check.
+   * @return True if the string is a keyword, false otherwise.
    */
-  Result<Token> readIdentifier(std::pair<size_t, size_t> start);
+  bool isKeyword(const std::string &value) const;
+
+  /**
+   * @brief Reads an identifier or keyword token from the input.
+   * @param start The starting line and column of the token.
+   * @return The identifier or keyword token.
+   */
+  Result<Token> readIdentifierOrKeyword(std::pair<size_t, size_t> start);
 
   /**
    * @brief Reads a number token from the input.

--- a/include/lexer.h
+++ b/include/lexer.h
@@ -40,6 +40,7 @@ struct Token {
     COLON,      // Represents the colon ':'
     ARROW,      // Represents the arrow '->'
     ASSIGN,     // Represents the assignment operator '='
+    TYPE,       // Represents type annotations (e.g., int, float, string)
     KW_DEF,     // Represents the keyword 'def'
     KW_RETURN,  // Represents the keyword 'return'
     EOF_TOKEN,  // Represents the end of file
@@ -54,6 +55,7 @@ struct Token {
   Token(const Token &other) : _type(other._type), _value(other._value), _line(other._line), _column(other._column) {}
   Token(Token &&other) noexcept
       : _type(other._type), _value(std::move(other._value)), _line(other._line), _column(other._column) {}
+  ~Token() = default;
   Token &operator=(const Token &other) {
     if (this != &other) {
       _type = other._type;
@@ -177,7 +179,7 @@ private:
    */
   bool isSymbol(char ch) const;
 
-  /*
+  /**
    * @brief Identifies if a string is a keyword.
    * @param value The string to check.
    * @return The token type if the string is a keyword, std::unexpected otherwise.
@@ -185,11 +187,18 @@ private:
   Result<Token::Type> isKeyword(const std::string &value) const;
 
   /**
+   * @brief Identifies if a string is a type.
+   * @param value The string to check.
+   * @return The token type if the string is a type, std::unexpected otherwise.
+   */
+  Result<Token::Type> isType(const std::string &value) const;
+
+  /**
    * @brief Reads an identifier or keyword token from the input.
    * @param start The starting line and column of the token.
    * @return The identifier or keyword token.
    */
-  Result<Token> readIdentifierOrKeyword(std::pair<size_t, size_t> start);
+  Result<Token> readIdentifierOrKeywordOrType(std::pair<size_t, size_t> start);
 
   /**
    * @brief Reads a number token from the input.

--- a/include/mlir_gen.h
+++ b/include/mlir_gen.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <mlir/IR/MLIRContext.h>
 #include <unordered_map>
 #include <string>
 #include <vector>
@@ -23,18 +24,19 @@ namespace picceler {
  * This offers the initial IR generation from the AST.
  */
 class MLIRGen {
-
 public:
   using GeneratorFunction = std::function<mlir::Value(mlir::Location, const std::vector<mlir::Value> &)>;
+  using VariableTable = std::unordered_map<std::string, mlir::Value>;
+  using NamedVariableTable = std::pair<std::string, VariableTable>;
 
 public:
+  MLIRGen() = delete;
   MLIRGen(mlir::MLIRContext *context);
-
-  bool normalizeASTMain(mlir::ModuleOp module, ModuleNode *root);
-  void declareUserFunctions(mlir::ModuleOp module, ModuleNode *root);
-  void defineUserFunctions(mlir::ModuleOp module, ModuleNode *root);
-
-  std::vector<mlir::Type> getFunctionArgTypes(FunctionNode *funcNode);
+  MLIRGen(const MLIRGen &) = default;
+  MLIRGen &operator=(const MLIRGen &) = default;
+  MLIRGen(MLIRGen &&) = default;
+  MLIRGen &operator=(MLIRGen &&) = default;
+  ~MLIRGen();
 
   /**
    * @brief Generates MLIR code from the given AST root node.
@@ -44,6 +46,60 @@ public:
   mlir::ModuleOp generate(ModuleNode *root);
 
 private:
+  /**
+   * @brief Normalizes the AST by processing all top-level statements in the module and assign to main if not found.
+   * @param module The MLIR module operation.
+   * @param root The root node of the AST.
+   * @return True if normalization is successful, false otherwise.
+   */
+  bool normalizeASTMain(mlir::ModuleOp module, ModuleNode *root);
+
+  /**
+   * @brief Declares user-defined functions in the MLIR module.
+   * @param module The MLIR module operation.
+   * @param root The root node of the AST.
+   */
+  void declareUserFunctions(mlir::ModuleOp module, ModuleNode *root);
+
+  /**
+   * @brief Defines user-defined functions in the MLIR module.
+   * @param module The MLIR module operation.
+   * @param root The root node of the AST.
+   */
+  void defineUserFunctions(mlir::ModuleOp module, ModuleNode *root);
+
+  /**
+   *    @brief Retrieves the argument types for a given function node.
+   *    @param funcNode The function node to retrieve argument types from.
+   *    @return A vector of MLIR types representing the argument types of the function.
+   */
+  std::vector<mlir::Type> getFunctionArgTypes(FunctionNode *funcNode);
+
+  /**
+   * @brief Looks up a variable in the known scopes and returns its MLIR value if found.
+   * @param name The name of the variable to look up.
+   * @return The MLIR value of the variable if found, or an error if not found.
+   */
+  Result<mlir::Value> lookupVariable(const std::string &name) const;
+
+  /**
+   * @brief Declares a variable in the current scope with the given name and MLIR value.
+   * @param name The name of the variable to declare.
+   * @param value The MLIR value of the variable.
+   */
+  void declareVariable(const std::string &name, mlir::Value value);
+
+  /**
+   * @brief Enters a new scope with the given name.
+   * @param name The name of the scope to enter.
+   */
+  void enterScope(const std::string &name);
+
+  /**
+   * @brief Exits the current scope.
+   */
+  void exitScope();
+
   /**
    * @brief Emits MLIR code for a given AST node.
    * @param node The AST node to emit from.
@@ -67,12 +123,15 @@ private:
    * \}
    */
 
+  /**
+   * @brief Registers all builtin functions with the generator.
+   */
   void registerBuiltinFunctions();
 
 private:
   mlir::MLIRContext *_context;
   mlir::OpBuilder _builder;
-  std::unordered_map<std::string, mlir::Value> _variableTable;
+  std::vector<NamedVariableTable> _scopedVariableTable;
   std::unordered_map<std::string, GeneratorFunction> _functionTable;
 };
 

--- a/include/mlir_gen.h
+++ b/include/mlir_gen.h
@@ -13,6 +13,7 @@
 #include "mlir/Pass/Pass.h"
 
 #include "dialect.h"
+#include "types.h"
 #include "parser.h"
 
 namespace picceler {
@@ -22,8 +23,18 @@ namespace picceler {
  * This offers the initial IR generation from the AST.
  */
 class MLIRGen {
+
+public:
+  using GeneratorFunction = std::function<mlir::Value(mlir::Location, const std::vector<mlir::Value> &)>;
+
 public:
   MLIRGen(mlir::MLIRContext *context);
+
+  bool normalizeASTMain(mlir::ModuleOp module, ModuleNode *root);
+  void declareUserFunctions(mlir::ModuleOp module, ModuleNode *root);
+  void defineUserFunctions(mlir::ModuleOp module, ModuleNode *root);
+
+  std::vector<mlir::Type> getFunctionArgTypes(FunctionNode *funcNode);
 
   /**
    * @brief Generates MLIR code from the given AST root node.
@@ -50,37 +61,19 @@ private:
   mlir::Value emitVariable(VariableNode *node);
   mlir::Value emitString(StringNode *node);
   mlir::Value emitNumber(NumberNode *node);
-  mlir::Value emitBuiltinCall(CallNode *node, const std::vector<mlir::Value> &args);
+  mlir::Value emitCallExpression(CallNode *node, const std::vector<mlir::Value> &args);
 
   /**
    * \}
    */
 
-  /**
-   * @brief Checks if a function call is to a built-in function.
-   * @param node The function call AST node.
-   * @return True if it's a built-in function, false otherwise.
-   */
-  bool isBuiltinFunction(CallNode *node);
-
-  /**
-   * @brief Provides a mapping of built-in variable names to their MLIR values.
-   * @return An unordered map of built-in variable names to MLIR values.
-   */
-  std::unordered_map<std::string, mlir::Value> builtinVariables();
-
-  /**
-   * @brief Provides a mapping of built-in function names to their MLIR function
-   * ops.
-   * @return An unordered map of built-in function names to MLIR function ops.
-   */
-  std::unordered_map<std::string, mlir::func::FuncOp> builtinFunctions();
+  void registerBuiltinFunctions();
 
 private:
   mlir::MLIRContext *_context;
   mlir::OpBuilder _builder;
   std::unordered_map<std::string, mlir::Value> _variableTable;
-  std::unordered_map<std::string, mlir::func::FuncOp> _functionTable;
+  std::unordered_map<std::string, GeneratorFunction> _functionTable;
 };
 
 } // namespace picceler

--- a/include/parser.h
+++ b/include/parser.h
@@ -52,6 +52,7 @@ private:
    */
   Result<std::unique_ptr<ASTNode>> parseStatement();
   Result<std::unique_ptr<ASTNode>> parseExpression();
+  Result<std::unique_ptr<ASTNode>> parseFunctionDefinition(Token defToken);
   Result<std::unique_ptr<ASTNode>> parseAssignment(Token identifier);
   Result<std::unique_ptr<ASTNode>> parseCall(Token identifier);
   Result<std::unique_ptr<ASTNode>> parseVariable(Token identifier = Token{Token::Type::UNKNOWN, "", 0, 0});

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -6,6 +6,23 @@ namespace picceler {
 
 std::string ModuleNode::toString() const { return std::format("Module: {} statements", statements.size()); }
 
+std::string FunctionNode::toString() const {
+  std::string params;
+  for (const auto &param : parameters) {
+    if (!params.empty()) {
+      params += ", ";
+    }
+    params += std::format("{}: {}", param.first, param.second);
+  }
+  std::string statements;
+  if (!body.empty()) {
+    for (const auto &statement : body) {
+      statements += "\t" + statement->toString() + "\n";
+    }
+  }
+  return std::format("Function:[{}({})] {{\n{}}}", name, params, statements);
+}
+
 std::string VariableNode::toString() const { return std::format("Variable:[{}]", name); }
 
 std::string StringNode::toString() const { return std::format("String:[{}]", value); }

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -2,14 +2,12 @@
 
 #include <cstdlib>
 
-#include "spdlog/cfg/env.h"
 #include "spdlog/spdlog.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Target/LLVMIR/Export.h"
-#include "mlir/Target/LLVMIR/LLVMTranslationInterface.h"
 #include "mlir/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.h"
 #include "mlir/Target/LLVMIR/Dialect/Builtin/BuiltinToLLVMIRTranslation.h"
 #include "llvm/IR/Module.h"
@@ -29,7 +27,6 @@ namespace picceler {
 Compiler::Compiler()
     : _cliApp("picceler compiler"), _cliOptions(), _parser(), _context(initRegistry()), _mlirGen(&_context),
       _passManager(&_context) {
-  spdlog::cfg::load_env_levels();
   _cliApp.add_option("input_file", _cliOptions.inputFile, "Input source file")->required()->check(CLI::ExistingFile);
   _cliApp.add_option("-o,--output", _cliOptions.outputFile, "Output executable file")->default_val("a.out");
 

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -147,12 +147,16 @@ bool Lexer::isSymbol(char ch) const {
   return _symbols.find(ch) != std::string::npos;
 }
 
-bool Lexer::isKeyword(const std::string &value) const {
+Result<Token::Type> Lexer::isKeyword(const std::string &value) const {
   static const std::unordered_map<std::string, Token::Type> keywords = {
       {"def", Token::Type::KW_DEF},
       {"return", Token::Type::KW_RETURN},
   };
-  return keywords.find(value) != keywords.end();
+  auto it = keywords.find(value);
+  if (it != keywords.end()) {
+    return it->second;
+  }
+  return std::unexpected(CompileError{std::format("Not a keyword: {}", value)});
 }
 
 Result<Token> Lexer::readIdentifierOrKeyword(std::pair<size_t, size_t> start) {
@@ -160,8 +164,10 @@ Result<Token> Lexer::readIdentifierOrKeyword(std::pair<size_t, size_t> start) {
   while (!eof() && (isalnum(peek()) || peek() == '_')) {
     value += get();
   }
-  if (isKeyword(value)) {
-    return Token{Token::Type::KW_DEF, value, start.first, start.second};
+  auto result = isKeyword(value);
+  if (result) {
+    Token::Type keywordType = *result;
+    return Token{keywordType, value, start.first, start.second};
   }
   return Token{Token::Type::IDENTIFIER, value, start.first, start.second};
 }

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -35,6 +35,8 @@ std::string Token::typeToString() const {
     return "ARROW";
   case Type::ASSIGN:
     return "ASSIGN";
+  case Type::TYPE:
+    return "TYPE";
   case Type::KW_DEF:
     return "KW_DEF";
   case Type::KW_RETURN:
@@ -75,7 +77,7 @@ Result<Token> Lexer::nextToken() {
   char ch;
   ch = peek();
   if (isIdentifier(ch)) {
-    return readIdentifierOrKeyword({_line, _column});
+    return readIdentifierOrKeywordOrType({_line, _column});
   }
   if (isdigit(ch) || ch == '-') {
     return readNumber({_line, _column});
@@ -159,7 +161,20 @@ Result<Token::Type> Lexer::isKeyword(const std::string &value) const {
   return std::unexpected(CompileError{std::format("Not a keyword: {}", value)});
 }
 
-Result<Token> Lexer::readIdentifierOrKeyword(std::pair<size_t, size_t> start) {
+Result<Token::Type> Lexer::isType(const std::string &value) const {
+  static const std::unordered_map<std::string, Token::Type> types = {
+      {"int", Token::Type::TYPE},
+      {"float", Token::Type::TYPE},
+      {"string", Token::Type::TYPE},
+  };
+  auto it = types.find(value);
+  if (it != types.end()) {
+    return it->second;
+  }
+  return std::unexpected(CompileError{std::format("Not a type: {}", value)});
+}
+
+Result<Token> Lexer::readIdentifierOrKeywordOrType(std::pair<size_t, size_t> start) {
   std::string value;
   while (!eof() && (isalnum(peek()) || peek() == '_')) {
     value += get();
@@ -168,6 +183,11 @@ Result<Token> Lexer::readIdentifierOrKeyword(std::pair<size_t, size_t> start) {
   if (result) {
     Token::Type keywordType = *result;
     return Token{keywordType, value, start.first, start.second};
+  }
+  result = isType(value);
+  if (result) {
+    Token::Type typeType = *result;
+    return Token{typeType, value, start.first, start.second};
   }
   return Token{Token::Type::IDENTIFIER, value, start.first, start.second};
 }

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -15,15 +15,34 @@ std::string Token::typeToString() const {
     return "NUMBER";
   case Type::STRING:
     return "STRING";
-  case Type::SYMBOL:
-    return "SYMBOL";
+  case Type::L_PAREN:
+    return "L_PAREN";
+  case Type::R_PAREN:
+    return "R_PAREN";
+  case Type::L_BRACKET:
+    return "L_BRACKET";
+  case Type::R_BRACKET:
+    return "R_BRACKET";
+  case Type::L_BRACE:
+    return "L_BRACE";
+  case Type::R_BRACE:
+    return "R_BRACE";
+  case Type::COMMA:
+    return "COMMA";
+  case Type::COLON:
+    return "COLON";
+  case Type::ARROW:
+    return "ARROW";
+  case Type::ASSIGN:
+    return "ASSIGN";
+  case Type::KW_DEF:
+    return "KW_DEF";
+  case Type::KW_RETURN:
+    return "KW_RETURN";
   case Type::EOF_TOKEN:
-    return "EOF";
-  case Type::UNKNOWN:
-    return "UNKNOWN";
+    return "EOF_TOKEN";
   default:
-    spdlog::error("Invalid token type");
-    return "INVALID";
+    return "UNKNOWN";
   }
 }
 
@@ -56,7 +75,7 @@ Result<Token> Lexer::nextToken() {
   char ch;
   ch = peek();
   if (isIdentifier(ch)) {
-    return readIdentifier({_line, _column});
+    return readIdentifierOrKeyword({_line, _column});
   }
   if (isdigit(ch) || ch == '-') {
     return readNumber({_line, _column});
@@ -100,7 +119,7 @@ Result<std::vector<Token>> Lexer::tokenizeAll() {
       spdlog::error(token.error().message());
       return std::unexpected(CompileError{"Failed to tokenize the entire source file"});
     }
-  } while (token.value()._type != Token::Type::EOF_TOKEN);
+  } while (*token != Token::Type::EOF_TOKEN);
   return tokens;
 }
 
@@ -124,14 +143,25 @@ char Lexer::get() {
 bool Lexer::isIdentifier(char ch) const { return isalpha(ch) || ch == '_'; }
 
 bool Lexer::isSymbol(char ch) const {
-  static const std::string _symbols = "=():,[]";
+  static const std::string _symbols = "=():,[]{}->=";
   return _symbols.find(ch) != std::string::npos;
 }
 
-Result<Token> Lexer::readIdentifier(std::pair<size_t, size_t> start) {
+bool Lexer::isKeyword(const std::string &value) const {
+  static const std::unordered_map<std::string, Token::Type> keywords = {
+      {"def", Token::Type::KW_DEF},
+      {"return", Token::Type::KW_RETURN},
+  };
+  return keywords.find(value) != keywords.end();
+}
+
+Result<Token> Lexer::readIdentifierOrKeyword(std::pair<size_t, size_t> start) {
   std::string value;
   while (!eof() && (isalnum(peek()) || peek() == '_')) {
     value += get();
+  }
+  if (isKeyword(value)) {
+    return Token{Token::Type::KW_DEF, value, start.first, start.second};
   }
   return Token{Token::Type::IDENTIFIER, value, start.first, start.second};
 }
@@ -175,7 +205,34 @@ Result<Token> Lexer::readString(std::pair<size_t, size_t> start) {
 
 Result<Token> Lexer::readSymbol(std::pair<size_t, size_t> start) {
   char ch = get();
-  return Token{Token::Type::SYMBOL, std::string(1, ch), start.first, start.second};
+  switch (ch) {
+  case '(':
+    return Token{Token::Type::L_PAREN, "(", start.first, start.second};
+  case ')':
+    return Token{Token::Type::R_PAREN, ")", start.first, start.second};
+  case '[':
+    return Token{Token::Type::L_BRACKET, "[", start.first, start.second};
+  case ']':
+    return Token{Token::Type::R_BRACKET, "]", start.first, start.second};
+  case '{':
+    return Token{Token::Type::L_BRACE, "{", start.first, start.second};
+  case '}':
+    return Token{Token::Type::R_BRACE, "}", start.first, start.second};
+  case ',':
+    return Token{Token::Type::COMMA, ",", start.first, start.second};
+  case ':':
+    return Token{Token::Type::COLON, ":", start.first, start.second};
+  case '-':
+    if (!eof() && peek() == '>') {
+      get(); // consume '>'
+      return Token{Token::Type::ARROW, "->", start.first, start.second};
+    }
+    return Token{Token::Type::UNKNOWN, std::string(1, ch), start.first, start.second};
+  case '=':
+    return Token{Token::Type::ASSIGN, "=", start.first, start.second};
+  default:
+    return Token{Token::Type::UNKNOWN, std::string(1, ch), start.first, start.second};
+  }
 }
 
 std::ostream &operator<<(std::ostream &os, const Token &token) {

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -163,9 +163,10 @@ Result<Token::Type> Lexer::isKeyword(const std::string &value) const {
 
 Result<Token::Type> Lexer::isType(const std::string &value) const {
   static const std::unordered_map<std::string, Token::Type> types = {
-      {"int", Token::Type::TYPE},
-      {"float", Token::Type::TYPE},
+      {"int64", Token::Type::TYPE},
+      {"f64", Token::Type::TYPE},
       {"string", Token::Type::TYPE},
+      {"image", Token::Type::TYPE},
   };
   auto it = types.find(value);
   if (it != types.end()) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,11 +1,10 @@
-#include <vector>
-
 #include "CLI/CLI.hpp"
-#include "spdlog/spdlog.h"
+#include "spdlog/cfg/env.h"
 
 #include "compiler.h"
 
 int main(int argc, char **argv) {
+  spdlog::cfg::load_env_levels();
   picceler::Compiler compiler;
   CLI11_PARSE(compiler.getCliApp(), argc, argv);
 

--- a/src/mlir_gen.cpp
+++ b/src/mlir_gen.cpp
@@ -111,6 +111,7 @@ bool MLIRGen::normalizeASTMain(mlir::ModuleOp module, ModuleNode *root) {
       root->statements.push_back(std::move(mainFunc));
     } else {
       spdlog::error("No 'main' function found and no top-level statements to wrap.");
+      return false;
     }
   } else {
     if (!onlyFunctions) {
@@ -173,17 +174,18 @@ void MLIRGen::defineUserFunctions(mlir::ModuleOp module, ModuleNode *root) {
       }
       spdlog::debug("Defining function: {}", funcNode->name);
 
+      mlir::OpBuilder::InsertionGuard guard(_builder);
+      _builder.setInsertionPointToStart(funcOp.addEntryBlock());
+
       enterScope(funcNode->name);
 
       int argIndex = 0;
-      for (auto &[paramName, paramType] : funcNode->parameters) {
+      for (const auto &[paramName, paramType] : funcNode->parameters) {
+        (void)paramType; // Suppress unused variable warning
         auto argValue = funcOp.getArgument(argIndex);
         declareVariable(paramName, argValue);
         ++argIndex;
       }
-
-      mlir::OpBuilder::InsertionGuard guard(_builder);
-      _builder.setInsertionPointToStart(funcOp.addEntryBlock());
 
       for (const auto &bodyStmt : funcNode->body) {
         emitStatement(bodyStmt.get());

--- a/src/mlir_gen.cpp
+++ b/src/mlir_gen.cpp
@@ -2,6 +2,7 @@
 
 #include <cmath>
 #include <limits>
+#include <print>
 
 #include "llvm/ADT/APFloat.h"
 
@@ -68,6 +69,115 @@ mlir::Value coerceValueToInt64(mlir::OpBuilder &builder, mlir::Location loc, mli
 MLIRGen::MLIRGen(mlir::MLIRContext *context)
     : _context(context), _builder(_context), _variableTable(), _functionTable() {}
 
+bool MLIRGen::normalizeASTMain(mlir::ModuleOp module, ModuleNode *root) {
+  bool hasMain = false;
+  bool onlyFunctions = true;
+  spdlog::info("Printing all statements in the AST:\n");
+  for (const auto &stmt : root->statements) {
+    spdlog::info("{}\n", stmt->toString());
+  }
+
+  for (const auto &stmt : root->statements) {
+    if (auto funcNode = dynamic_cast<FunctionNode *>(stmt.get())) {
+      if (funcNode->name == "main") {
+        hasMain = true;
+      }
+    } else {
+      onlyFunctions = false;
+    }
+  }
+
+  if (!hasMain) {
+    if (!onlyFunctions) {
+      spdlog::warn("No 'main' functions found, implicit 'main' will be generated to wrap the top-level statements");
+      auto mainFunc = std::make_unique<FunctionNode>();
+      mainFunc->name = "main";
+      for (auto &stmt : root->statements) {
+        if (!dynamic_cast<FunctionNode *>(stmt.get())) {
+          mainFunc->body.push_back(std::move(stmt));
+        }
+      }
+      root->statements.erase(std::remove_if(root->statements.begin(), root->statements.end(),
+                                            [&](const std::unique_ptr<ASTNode> &stmt) {
+                                              return !dynamic_cast<FunctionNode *>(stmt.get());
+                                            }),
+                             root->statements.end());
+      root->statements.push_back(std::move(mainFunc));
+    } else {
+      spdlog::error("No 'main' function found and no top-level statements to wrap.");
+    }
+  } else {
+    if (!onlyFunctions) {
+      spdlog::warn("Found 'main' function, but also found top-level statements. Not allowed.");
+      return false;
+    }
+  }
+
+  spdlog::info("AST normalization complete. Final AST:\n");
+  for (const auto &stmt : root->statements) {
+    spdlog::info("{}\n", stmt->toString());
+  }
+  return true;
+}
+
+void MLIRGen::declareUserFunctions(mlir::ModuleOp module, ModuleNode *root) {
+  _builder.setInsertionPointToStart(module.getBody());
+  for (const auto &stmt : root->statements) {
+    if (auto funcNode = dynamic_cast<FunctionNode *>(stmt.get())) {
+      std::vector<mlir::Type> funcArgTypes = getFunctionArgTypes(funcNode);
+      auto funcType = _builder.getFunctionType(funcArgTypes, {});
+      auto funcOp = _builder.create<mlir::func::FuncOp>(_builder.getUnknownLoc(), funcNode->name, funcType);
+      _functionTable[funcNode->name] = [&, funcOp](mlir::Location loc, const std::vector<mlir::Value> &args) {
+        auto callOp = _builder.create<mlir::func::CallOp>(loc, funcOp, args);
+        return callOp.getNumResults() > 0 ? callOp.getResult(0) : mlir::Value();
+      };
+    } else {
+      spdlog::error("Unexpected statement type in AST: {}", stmt->toString());
+    }
+  }
+}
+
+std::vector<mlir::Type> MLIRGen::getFunctionArgTypes(FunctionNode *funcNode) {
+  std::vector<mlir::Type> argTypes;
+  for (const auto &[paramName, paramType] : funcNode->parameters) {
+    if (paramType == "image") {
+      argTypes.push_back(_builder.getType<ImageType>());
+    } else if (paramType == "string") {
+      argTypes.push_back(_builder.getType<StringType>());
+    } else if (paramType == "f64") {
+      argTypes.push_back(_builder.getF64Type());
+    } else if (paramType == "int64") {
+      argTypes.push_back(_builder.getI64Type());
+    } else {
+      throw std::runtime_error("Unsupported parameter type: " + paramType);
+    }
+  }
+  return argTypes;
+}
+
+void MLIRGen::defineUserFunctions(mlir::ModuleOp module, ModuleNode *root) {
+  for (const auto &stmt : root->statements) {
+    if (auto funcNode = dynamic_cast<FunctionNode *>(stmt.get())) {
+      auto funcOp = module.lookupSymbol<mlir::func::FuncOp>(funcNode->name);
+      if (!funcOp) {
+        throw std::runtime_error("Function not declared: " + funcNode->name);
+      }
+
+      mlir::OpBuilder::InsertionGuard guard(_builder);
+      _builder.setInsertionPointToStart(funcOp.addEntryBlock());
+
+      for (const auto &bodyStmt : funcNode->body) {
+        emitStatement(bodyStmt.get());
+      }
+
+      _builder.create<mlir::func::ReturnOp>(_builder.getUnknownLoc());
+    } else {
+      spdlog::error("Unexpected statement type in AST: {} -- parsing only FunctionNodes to emit code",
+                    stmt->toString());
+    }
+  }
+}
+
 /**
  * @brief Generates MLIR code from the given AST root node.
  * @param root The root node of the AST.
@@ -75,22 +185,14 @@ MLIRGen::MLIRGen(mlir::MLIRContext *context)
  */
 mlir::ModuleOp MLIRGen::generate(ModuleNode *root) {
   auto module = mlir::ModuleOp::create(_builder.getUnknownLoc());
-  // Create a top-level main function to own all generated ops.
-  auto funcType = _builder.getFunctionType({}, {});
-  auto mainFunc = _builder.create<mlir::func::FuncOp>(_builder.getUnknownLoc(), "main", funcType);
-  auto *entryBlock = mainFunc.addEntryBlock();
-  _builder.setInsertionPointToStart(entryBlock);
-  _variableTable = builtinVariables();
-  _functionTable = builtinFunctions();
+  registerBuiltinFunctions();
 
-  for (auto &stmt : root->statements) {
-    emitStatement(stmt.get());
+  bool result = normalizeASTMain(module, root);
+  if (!result) {
+    return nullptr;
   }
-
-  // Terminate the function.
-  _builder.create<mlir::func::ReturnOp>(_builder.getUnknownLoc());
-
-  module.push_back(mainFunc);
+  declareUserFunctions(module, root);
+  defineUserFunctions(module, root);
 
   return module;
 }
@@ -165,7 +267,7 @@ mlir::Value MLIRGen::emitCall(CallNode *node) {
   for (auto &arg : node->arguments) {
     args.push_back(emitExpression(arg.get()));
   }
-  auto op = emitBuiltinCall(node, args);
+  auto op = emitCallExpression(node, args);
   return op;
 }
 
@@ -191,126 +293,140 @@ mlir::Value MLIRGen::emitNumber(NumberNode *node) {
                                                        llvm::APFloat(node->value));
 }
 
-mlir::Value MLIRGen::emitBuiltinCall(CallNode *node, const std::vector<mlir::Value> &args) {
-  const auto &name = node->callee;
-  if (name == "load_image") {
+void MLIRGen::registerBuiltinFunctions() {
+  _functionTable["load_image"] = [&](mlir::Location loc, const std::vector<mlir::Value> &args) {
     auto imageType = _builder.getType<ImageType>();
     auto filename = args[0];
-    auto callOp = _builder.create<LoadImageOp>(_builder.getUnknownLoc(), imageType, filename);
+    auto callOp = _builder.create<LoadImageOp>(loc, imageType, filename);
     return callOp.getResult();
-  } else if (name == "save_image") {
+  };
+  _functionTable["save_image"] = [&](mlir::Location loc, const std::vector<mlir::Value> &args) {
     auto &inputImage = args[0];
     auto &filename = args[1];
-    _builder.create<SaveImageOp>(_builder.getUnknownLoc(), inputImage, filename);
-    return {};
-  } else if (name == "show_image") {
+    _builder.create<SaveImageOp>(loc, inputImage, filename);
+    return mlir::Value(); // Return an empty value for void functions
+  };
+  _functionTable["show_image"] = [&](mlir::Location loc, const std::vector<mlir::Value> &args) {
     auto &inputImage = args[0];
-    _builder.create<ShowImageOp>(_builder.getUnknownLoc(), inputImage);
-    return {};
-  } else if (name == "brightness") {
+    _builder.create<ShowImageOp>(loc, inputImage);
+    return mlir::Value(); // Return an empty value for void functions
+  };
+  _functionTable["brightness"] = [&](mlir::Location loc, const std::vector<mlir::Value> &args) {
     auto &inputImage = args[0];
-    auto brightnessValue = coerceValueToInt64(_builder, _builder.getUnknownLoc(), args[1], "brightness", "value");
-    auto callOp =
-        _builder.create<BrightnessOp>(_builder.getUnknownLoc(), inputImage.getType(), inputImage, brightnessValue);
+    auto brightnessValue = coerceValueToInt64(_builder, loc, args[1], "brightness", "value");
+    auto callOp = _builder.create<BrightnessOp>(loc, inputImage.getType(), inputImage, brightnessValue);
     return callOp.getResult();
-  } else if (name == "invert") {
+  };
+  _functionTable["invert"] = [&](mlir::Location loc, const std::vector<mlir::Value> &args) {
     auto &inputImage = args[0];
-    auto callOp = _builder.create<InvertOp>(_builder.getUnknownLoc(), inputImage.getType(), inputImage);
+    auto callOp = _builder.create<InvertOp>(loc, inputImage.getType(), inputImage);
     return callOp.getResult();
-  } else if (name == "convolution") {
+  };
+  _functionTable["convolution"] = [&](mlir::Location loc, const std::vector<mlir::Value> &args) {
     auto &inputImage = args[0];
     auto &kernel = args[1];
-    auto callOp = _builder.create<ConvolutionOp>(_builder.getUnknownLoc(), inputImage.getType(), inputImage, kernel);
+    auto callOp = _builder.create<ConvolutionOp>(loc, inputImage.getType(), inputImage, kernel);
     return callOp.getResult();
-  } else if (name == "sharpen") {
+  };
+  _functionTable["sharpen"] = [&](mlir::Location loc, const std::vector<mlir::Value> &args) {
     auto &inputImage = args[0];
-    auto strengthValue = coerceValueToInt64(_builder, _builder.getUnknownLoc(), args[1], "sharpen", "strength");
-    auto callOp = _builder.create<SharpenOp>(_builder.getUnknownLoc(), inputImage.getType(), inputImage, strengthValue);
+    auto strengthValue = coerceValueToInt64(_builder, loc, args[1], "sharpen", "strength");
+    auto callOp = _builder.create<SharpenOp>(loc, inputImage.getType(), inputImage, strengthValue);
     return callOp.getResult();
-  } else if (name == "box_blur") {
+  };
+  _functionTable["box_blur"] = [&](mlir::Location loc, const std::vector<mlir::Value> &args) {
     auto &inputImage = args[0];
-    auto radiusValue = coerceValueToInt64(_builder, _builder.getUnknownLoc(), args[1], "box_blur", "radius");
-    auto callOp = _builder.create<BoxBlurOp>(_builder.getUnknownLoc(), inputImage.getType(), inputImage, radiusValue);
+    auto radiusValue = coerceValueToInt64(_builder, loc, args[1], "box_blur", "radius");
+    auto callOp = _builder.create<BoxBlurOp>(loc, inputImage.getType(), inputImage, radiusValue);
     return callOp.getResult();
-  } else if (name == "gaussian_blur") {
+  };
+  _functionTable["gaussian_blur"] = [&](mlir::Location loc, const std::vector<mlir::Value> &args) {
     auto &inputImage = args[0];
-    auto radiusValue = coerceValueToInt64(_builder, _builder.getUnknownLoc(), args[1], "gaussian_blur", "radius");
-    auto callOp =
-        _builder.create<GaussianBlurOp>(_builder.getUnknownLoc(), inputImage.getType(), inputImage, radiusValue);
+    auto radiusValue = coerceValueToInt64(_builder, loc, args[1], "gaussian_blur", "radius");
+    auto callOp = _builder.create<GaussianBlurOp>(loc, inputImage.getType(), inputImage, radiusValue);
     return callOp.getResult();
-  } else if (name == "edge_detect") {
+  };
+  _functionTable["edge_detect"] = [&](mlir::Location loc, const std::vector<mlir::Value> &args) {
     auto &inputImage = args[0];
-    auto callOp = _builder.create<EdgeDetectOp>(_builder.getUnknownLoc(), inputImage.getType(), inputImage);
+    auto callOp = _builder.create<EdgeDetectOp>(loc, inputImage.getType(), inputImage);
     return callOp.getResult();
-  } else if (name == "emboss") {
+  };
+  _functionTable["emboss"] = [&](mlir::Location loc, const std::vector<mlir::Value> &args) {
     auto &inputImage = args[0];
-    auto callOp = _builder.create<EmbossOp>(_builder.getUnknownLoc(), inputImage.getType(), inputImage);
+    auto callOp = _builder.create<EmbossOp>(loc, inputImage.getType(), inputImage);
     return callOp.getResult();
-  } else if (name == "rotate") {
+  };
+  _functionTable["rotate"] = [&](mlir::Location loc, const std::vector<mlir::Value> &args) {
     auto &inputImage = args[0];
-    auto angle = coerceValueToInt64(_builder, _builder.getUnknownLoc(), args[1], "rotate", "angle");
-    auto callOp = _builder.create<RotateOp>(_builder.getUnknownLoc(), inputImage.getType(), inputImage, angle);
+    auto angle = coerceValueToInt64(_builder, loc, args[1], "rotate", "angle");
+    auto callOp = _builder.create<RotateOp>(loc, inputImage.getType(), inputImage, angle);
     return callOp.getResult();
-  } else if (name == "crop") {
+  };
+  _functionTable["crop"] = [&](mlir::Location loc, const std::vector<mlir::Value> &args) {
     auto &inputImage = args[0];
-    auto x = coerceValueToInt64(_builder, _builder.getUnknownLoc(), args[1], "crop", "x");
-    auto y = coerceValueToInt64(_builder, _builder.getUnknownLoc(), args[2], "crop", "y");
-    auto width = coerceValueToInt64(_builder, _builder.getUnknownLoc(), args[3], "crop", "width");
-    auto height = coerceValueToInt64(_builder, _builder.getUnknownLoc(), args[4], "crop", "height");
-    auto callOp =
-        _builder.create<CropOp>(_builder.getUnknownLoc(), inputImage.getType(), inputImage, x, y, width, height);
+    auto x = coerceValueToInt64(_builder, loc, args[1], "crop", "x");
+    auto y = coerceValueToInt64(_builder, loc, args[2], "crop", "y");
+    auto width = coerceValueToInt64(_builder, loc, args[3], "crop", "width");
+    auto height = coerceValueToInt64(_builder, loc, args[4], "crop", "height");
+    auto callOp = _builder.create<CropOp>(loc, inputImage.getType(), inputImage, x, y, width, height);
     return callOp.getResult();
-  } else if (name == "diff") {
+  };
+  _functionTable["diff"] = [&](mlir::Location loc, const std::vector<mlir::Value> &args) {
     auto &inputImage1 = args[0];
     auto &inputImage2 = args[1];
-    auto callOp = _builder.create<DiffOp>(_builder.getUnknownLoc(), inputImage1.getType(), inputImage1, inputImage2);
+    auto callOp = _builder.create<DiffOp>(loc, inputImage1.getType(), inputImage1, inputImage2);
     return callOp.getResult();
-  } else if (name == "dilate") {
+  };
+  _functionTable["dilate"] = [&](mlir::Location loc, const std::vector<mlir::Value> &args) {
     auto &inputImage = args[0];
-    auto radius = coerceValueToInt64(_builder, _builder.getUnknownLoc(), args[1], "dilate", "radius");
-    auto callOp = _builder.create<DilateOp>(_builder.getUnknownLoc(), inputImage.getType(), inputImage, radius);
+    auto radius = coerceValueToInt64(_builder, loc, args[1], "dilate", "radius");
+    auto callOp = _builder.create<DilateOp>(loc, inputImage.getType(), inputImage, radius);
     return callOp.getResult();
-  } else if (name == "erode") {
+  };
+  _functionTable["erode"] = [&](mlir::Location loc, const std::vector<mlir::Value> &args) {
     auto &inputImage = args[0];
-    auto radius = coerceValueToInt64(_builder, _builder.getUnknownLoc(), args[1], "erode", "radius");
-    auto callOp = _builder.create<ErodeOp>(_builder.getUnknownLoc(), inputImage.getType(), inputImage, radius);
+    auto radius = coerceValueToInt64(_builder, loc, args[1], "erode", "radius");
+    auto callOp = _builder.create<ErodeOp>(loc, inputImage.getType(), inputImage, radius);
     return callOp.getResult();
-  } else if (name == "blend") {
+  };
+  _functionTable["blend"] = [&](mlir::Location loc, const std::vector<mlir::Value> &args) {
     auto &inputImage1 = args[0];
     auto &inputImage2 = args[1];
     auto &weight = args[2];
-    auto callOp =
-        _builder.create<BlendOp>(_builder.getUnknownLoc(), inputImage1.getType(), inputImage1, inputImage2, weight);
+    auto callOp = _builder.create<BlendOp>(loc, inputImage1.getType(), inputImage1, inputImage2, weight);
     return callOp.getResult();
-  } else if (name == "read_number") {
+  };
+  _functionTable["read_number"] = [&](mlir::Location loc, const std::vector<mlir::Value> &args) {
     auto resultType = _builder.getType<mlir::Float64Type>();
     auto &prompt = args[0];
-    auto callOp = _builder.create<ReadNumberOp>(_builder.getUnknownLoc(), resultType, prompt);
+    auto callOp = _builder.create<ReadNumberOp>(loc, resultType, prompt);
     return callOp.getResult();
-  } else if (name == "read_string") {
+  };
+  _functionTable["read_string"] = [&](mlir::Location loc, const std::vector<mlir::Value> &args) {
     auto resultType = _builder.getType<StringType>();
     auto &prompt = args[0];
-    auto callOp = _builder.create<ReadStringOp>(_builder.getUnknownLoc(), resultType, prompt);
+    auto callOp = _builder.create<ReadStringOp>(loc, resultType, prompt);
     return callOp.getResult();
-  } else {
-    throw std::runtime_error("Unsupported builtin function: " + name);
-  }
+  };
 }
 
-std::unordered_map<std::string, mlir::Value> MLIRGen::builtinVariables() {
-  auto variables = std::unordered_map<std::string, mlir::Value>{};
-  auto stringType = StringType::get(_context);
+mlir::Value MLIRGen::emitCallExpression(CallNode *node, const std::vector<mlir::Value> &args) {
+  const auto &name = node->callee;
+  mlir::Location loc = _builder.getUnknownLoc();
 
-  // variables["gaussian"] =
-  //     _builder.create<StringConstOp>(_builder.getUnknownLoc(), stringType, mlir::StringAttr::get(_context,
-  //     "gaussian"));
+  auto expectedArgCount = node->arguments.size();
+  if (args.size() != expectedArgCount) {
+    // TODO: replace with Result<T> and proper error handling, more info on mismatch
+    throw std::runtime_error("Function call argument count mismatch for function: " + name);
+  }
 
-  return variables;
-};
-
-std::unordered_map<std::string, mlir::func::FuncOp> MLIRGen::builtinFunctions() {
-  auto functions = std::unordered_map<std::string, mlir::func::FuncOp>{};
-  return functions;
+  if (auto it = _functionTable.find(name); it != _functionTable.end()) {
+    auto funcOpResult = it->second(loc, args);
+    return funcOpResult;
+  } else {
+    // TODO: replace with Result<T> and proper error handling, more info
+    throw std::runtime_error("Unknown function: " + name);
+  }
 }
 
 } // namespace picceler

--- a/src/mlir_gen.cpp
+++ b/src/mlir_gen.cpp
@@ -2,7 +2,6 @@
 
 #include <cmath>
 #include <limits>
-#include <print>
 
 #include "llvm/ADT/APFloat.h"
 
@@ -30,13 +29,14 @@ namespace picceler {
 
 mlir::Value coerceValueToInt64(mlir::OpBuilder &builder, mlir::Location loc, mlir::Value value, llvm::StringRef opName,
                                llvm::StringRef argName) {
-  if (value.getType().isSignlessInteger(64)) {
+  auto intBitWidth = 64;
+  if (value.getType().isSignlessInteger(intBitWidth)) {
     return value;
   }
 
   // Accept a non-I64 integer constant directly.
   if (auto constInt = value.getDefiningOp<mlir::arith::ConstantIntOp>()) {
-    return builder.create<mlir::arith::ConstantIntOp>(loc, constInt.value(), 64);
+    return builder.create<mlir::arith::ConstantIntOp>(loc, constInt.value(), intBitWidth);
   }
 
   // Accept a floating-point constant only if it is a whole number.
@@ -56,7 +56,7 @@ mlir::Value coerceValueToInt64(mlir::OpBuilder &builder, mlir::Location loc, mli
       throw std::runtime_error(opName.str() + " integer literal is out of range");
     }
 
-    return builder.create<mlir::arith::ConstantIntOp>(loc, static_cast<int64_t>(numericValue), 64);
+    return builder.create<mlir::arith::ConstantIntOp>(loc, static_cast<int64_t>(numericValue), intBitWidth);
   }
 
   if (auto isRuntimeFloat = mlir::isa<mlir::FloatType>(value.getType())) {
@@ -67,7 +67,13 @@ mlir::Value coerceValueToInt64(mlir::OpBuilder &builder, mlir::Location loc, mli
 }
 
 MLIRGen::MLIRGen(mlir::MLIRContext *context)
-    : _context(context), _builder(_context), _variableTable(), _functionTable() {}
+    : _context(context), _builder(_context), _scopedVariableTable(), _functionTable() {
+  enterScope("Global"); // Enter the global scope
+}
+
+MLIRGen::~MLIRGen() {
+  exitScope(); // Exit the global scope
+}
 
 bool MLIRGen::normalizeASTMain(mlir::ModuleOp module, ModuleNode *root) {
   bool hasMain = false;
@@ -121,9 +127,11 @@ bool MLIRGen::normalizeASTMain(mlir::ModuleOp module, ModuleNode *root) {
 }
 
 void MLIRGen::declareUserFunctions(mlir::ModuleOp module, ModuleNode *root) {
+  spdlog::debug("Declaring user-defined functions in the MLIR module");
   _builder.setInsertionPointToStart(module.getBody());
   for (const auto &stmt : root->statements) {
     if (auto funcNode = dynamic_cast<FunctionNode *>(stmt.get())) {
+      spdlog::debug("Declaring function: {}", funcNode->name);
       std::vector<mlir::Type> funcArgTypes = getFunctionArgTypes(funcNode);
       auto funcType = _builder.getFunctionType(funcArgTypes, {});
       auto funcOp = _builder.create<mlir::func::FuncOp>(_builder.getUnknownLoc(), funcNode->name, funcType);
@@ -156,11 +164,22 @@ std::vector<mlir::Type> MLIRGen::getFunctionArgTypes(FunctionNode *funcNode) {
 }
 
 void MLIRGen::defineUserFunctions(mlir::ModuleOp module, ModuleNode *root) {
+  spdlog::debug("Defining user-defined functions in the MLIR module");
   for (const auto &stmt : root->statements) {
     if (auto funcNode = dynamic_cast<FunctionNode *>(stmt.get())) {
       auto funcOp = module.lookupSymbol<mlir::func::FuncOp>(funcNode->name);
       if (!funcOp) {
         throw std::runtime_error("Function not declared: " + funcNode->name);
+      }
+      spdlog::debug("Defining function: {}", funcNode->name);
+
+      enterScope(funcNode->name);
+
+      int argIndex = 0;
+      for (auto &[paramName, paramType] : funcNode->parameters) {
+        auto argValue = funcOp.getArgument(argIndex);
+        declareVariable(paramName, argValue);
+        ++argIndex;
       }
 
       mlir::OpBuilder::InsertionGuard guard(_builder);
@@ -169,6 +188,8 @@ void MLIRGen::defineUserFunctions(mlir::ModuleOp module, ModuleNode *root) {
       for (const auto &bodyStmt : funcNode->body) {
         emitStatement(bodyStmt.get());
       }
+
+      exitScope();
 
       _builder.create<mlir::func::ReturnOp>(_builder.getUnknownLoc());
     } else {
@@ -251,16 +272,63 @@ mlir::Value MLIRGen::emitExpression(ASTNode *node) {
   }
 }
 
+Result<mlir::Value> MLIRGen::lookupVariable(const std::string &name) const {
+  for (auto it = _scopedVariableTable.rbegin(); it != _scopedVariableTable.rend(); ++it) {
+    const auto &scope = it->second;
+    auto found = scope.find(name);
+    if (found != scope.end()) {
+      return found->second;
+    }
+  }
+  return std::unexpected(CompileError{"Undefined variable: " + name});
+}
+
+void MLIRGen::declareVariable(const std::string &varName, mlir::Value value) {
+  if (_scopedVariableTable.empty()) {
+    _scopedVariableTable.emplace_back();
+  }
+  auto &currentScope = _scopedVariableTable.back();
+  auto &scopeName = currentScope.first;
+  auto &scope = currentScope.second;
+  spdlog::debug("Declaring variable: {} for scope: {}", varName, scopeName);
+  scope[varName] = value;
+}
+
+void MLIRGen::enterScope(const std::string &name) {
+  spdlog::debug("Entering scope: {}", name);
+  _scopedVariableTable.emplace_back(name, VariableTable());
+}
+
+void MLIRGen::exitScope() {
+  if (!_scopedVariableTable.empty()) {
+    _scopedVariableTable.pop_back();
+  } else {
+    throw std::runtime_error("Attempted to exit scope when no scopes are active");
+  }
+}
+
 /**
- * lhs - variable
- * rhs - expression
+ * img = load_image("input.png")
+ * ^ lhs
+ * %0 = load_image("input.png")
+ * ^ rhs
+ *
+ * lhs is the variable name
+ * rhs is the SSA value returned from the expression
  */
 mlir::Value MLIRGen::emitAssignment(AssignmentNode *node) {
   spdlog::debug("Emitting MLIR for assignment: {}", node->toString());
   auto rhs = emitExpression(node->rhs.get());
-  _variableTable[node->lhs->name] = rhs; // Bind 'img' to %0
+  auto varName = node->lhs->name;
+
+  auto var = lookupVariable(varName);
+  if (var) {
+    throw std::runtime_error("Variable already exists in the current scope and is immutable: " + varName);
+  }
+  declareVariable(varName, rhs);
   return rhs;
 }
+
 mlir::Value MLIRGen::emitCall(CallNode *node) {
   spdlog::debug("Emitting MLIR for call: {}", node->toString());
   std::vector<mlir::Value> args;
@@ -273,9 +341,12 @@ mlir::Value MLIRGen::emitCall(CallNode *node) {
 
 mlir::Value MLIRGen::emitVariable(VariableNode *node) {
   spdlog::debug("Emitting MLIR for variable: {}", node->toString());
-  auto it = _variableTable.find(node->name);
-  if (it != _variableTable.end()) {
-    return it->second;
+  auto var = lookupVariable(node->name);
+  if (var) {
+    return var.value();
+  } else {
+    spdlog::error("lookupVariable failed with error message {}", var.error().message());
+    spdlog::error("Undefined variable: {}", node->name);
   }
   throw std::runtime_error("Undefined variable: " + node->name);
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -50,8 +50,8 @@ Result<std::unique_ptr<ASTNode>> Parser::parseStatement() {
     return std::unexpected(CompileError{"parseStatement unexpected stop of parsing"});
   }
   auto token = *tokenResult;
-  if (token._type == Token::Type::IDENTIFIER) {
-    spdlog::debug("Parsing statement starting with identifier '{}'", token._value);
+  if (token == Token::Type::IDENTIFIER) {
+    spdlog::debug("Parsing statement starting with identifier '{}'", token.value());
     auto identifierResult = _lexer.nextToken();
     if (!identifierResult) {
       spdlog::error("{}", identifierResult.error().message());
@@ -64,34 +64,33 @@ Result<std::unique_ptr<ASTNode>> Parser::parseStatement() {
       return std::unexpected(CompileError{"Failed to peek next token"});
     }
     auto nextToken = *nextTokenResult;
-    if (nextToken._type == Token::Type::SYMBOL) {
-      if (nextToken._value == "=") {
-        return parseAssignment(identifier);
-      } else if (nextToken._value == "(") {
-        return parseCall(identifier);
-      }
+    if (nextToken == Token::Type::ASSIGN) {
+      return parseAssignment(identifier);
+    } else if (nextToken == Token::Type::L_PAREN) {
+      return parseCall(identifier);
     }
-    return std::unexpected(CompileError{
-        std::format("Unexpected token '{}' at {}:{}", nextToken._value, nextToken._line, nextToken._column)});
-  } else if (token._type == Token::Type::EOF_TOKEN) {
+    return std::unexpected(CompileError{std::format("Unexpected token '{}' after identifier at {}:{}",
+                                                    nextToken.value(), nextToken.line(), nextToken.column())});
+
+  } else if (token == Token::Type::EOF_TOKEN) {
     return nullptr;
   } else {
     return std::unexpected(
-        CompileError{std::format("Unexpected token '{}' at {}:{}", token._value, token._line, token._column)});
+        CompileError{std::format("Unexpected token '{}' at {}:{}", token.value(), token.line(), token.column())});
   }
 }
 
 Result<std::unique_ptr<ASTNode>> Parser::parseAssignment(Token identifier) {
-  spdlog::debug("Parsing assignment for identifier '{}'", identifier._value);
+  spdlog::debug("Parsing assignment for identifier '{}'", identifier.value());
   auto eqTokenResult = _lexer.nextToken(); // consume '='
   if (!eqTokenResult) {
     spdlog::error("{}", eqTokenResult.error().message());
     return std::unexpected(CompileError{"Failed to consume '=' token in assignment"});
   }
   auto eqToken = *eqTokenResult;
-  if (eqToken._type != Token::Type::SYMBOL || eqToken._value != "=") {
+  if (eqToken != Token::Type::ASSIGN) {
     return std::unexpected(
-        CompileError{std::format("Expected '=' after identifier at {}:{}", eqToken._line, eqToken._column)});
+        CompileError{std::format("Expected '=' after identifier at {}:{}", eqToken.line(), eqToken.column())});
   }
   auto exprResult = parseExpression();
   if (!exprResult) {
@@ -111,19 +110,19 @@ Result<std::unique_ptr<ASTNode>> Parser::parseAssignment(Token identifier) {
 }
 
 Result<std::unique_ptr<ASTNode>> Parser::parseCall(Token identifier) {
-  spdlog::debug("Parsing function call for identifier '{}'", identifier._value);
+  spdlog::debug("Parsing function call for identifier '{}'", identifier.value());
   auto lparenTokenResult = _lexer.nextToken(); // consume '('
   if (!lparenTokenResult) {
     spdlog::error("{}", lparenTokenResult.error().message());
     return std::unexpected(CompileError{"Failed to consume '(' token in function call"});
   }
   auto lparenToken = *lparenTokenResult;
-  if (lparenToken._type != Token::Type::SYMBOL || lparenToken._value != "(") {
-    return std::unexpected(
-        CompileError{std::format("Expected '(' after function name at {}:{}", lparenToken._line, lparenToken._column)});
+  if (lparenToken != Token::Type::L_PAREN) {
+    return std::unexpected(CompileError{
+        std::format("Expected '(' after function name at {}:{}", lparenToken.line(), lparenToken.column())});
   }
   auto callNode = std::make_unique<CallNode>();
-  callNode->callee = identifier._value;
+  callNode->callee = identifier.value();
 
   while (true) {
     auto nextTokenResult = _lexer.peekToken();
@@ -132,7 +131,7 @@ Result<std::unique_ptr<ASTNode>> Parser::parseCall(Token identifier) {
       return std::unexpected(CompileError{"Failed to peek next token in function call"});
     }
     auto nextToken = *nextTokenResult;
-    if (nextToken._type == Token::Type::SYMBOL && nextToken._value == ")") {
+    if (nextToken == Token::Type::R_PAREN) {
       auto rparenTokenResult = _lexer.nextToken(); // consume ')'
       if (!rparenTokenResult) {
         spdlog::error("{}", rparenTokenResult.error().message());
@@ -154,17 +153,17 @@ Result<std::unique_ptr<ASTNode>> Parser::parseCall(Token identifier) {
       return std::unexpected(CompileError{"Failed to peek next token in function call"});
     }
     nextToken = *nextTokenResult;
-    if (nextToken._type == Token::Type::SYMBOL && nextToken._value == ",") {
+    if (nextToken == Token::Type::COMMA) {
       auto commaTokenResult = _lexer.nextToken(); // consume ','
       if (!commaTokenResult) {
         spdlog::error("{}", commaTokenResult.error().message());
         return std::unexpected(CompileError{"Failed to consume ',' token in function call"});
       }
-    } else if (nextToken._type == Token::Type::SYMBOL && nextToken._value == ")") {
+    } else if (nextToken == Token::Type::R_PAREN) {
       continue;
     } else {
       return std::unexpected(CompileError{
-          std::format("Expected ',' or ')' in function call at {}:{}", nextToken._line, nextToken._column)});
+          std::format("Expected ',' or ')' in function call at {}:{}", nextToken.line(), nextToken.column())});
     }
   }
 
@@ -179,7 +178,7 @@ Result<std::unique_ptr<ASTNode>> Parser::parseExpression() {
     return std::unexpected(CompileError{"parseExpression unexpected stop of parsing"});
   }
   auto token = *tokenResult;
-  if (token._type == Token::Type::IDENTIFIER) {
+  if (token == Token::Type::IDENTIFIER) {
     auto currentTokenResult = _lexer.nextToken();
     if (!currentTokenResult) {
       spdlog::error("{}", currentTokenResult.error().message());
@@ -192,27 +191,27 @@ Result<std::unique_ptr<ASTNode>> Parser::parseExpression() {
       return std::unexpected(CompileError{"Failed to peek next token in expression"});
     }
     auto nextToken = *nextTokenResult;
-    if (nextToken._type == Token::Type::SYMBOL && nextToken._value == "(") {
+    if (nextToken == Token::Type::L_PAREN) {
       return parseCall(currentToken);
     } else {
       return parseVariable(currentToken);
     }
-  } else if (token._type == Token::Type::STRING) {
+  } else if (token == Token::Type::STRING) {
     return parseString();
-  } else if (token._type == Token::Type::NUMBER) {
+  } else if (token == Token::Type::NUMBER) {
     return parseNumber();
-  } else if (token._type == Token::Type::SYMBOL && token._value == "[") {
+  } else if (token == Token::Type::L_BRACKET) {
     return parseKernel();
   } else {
     return std::unexpected(
-        CompileError{std::format("Unexpected token '{}' at {}:{}", token._value, token._line, token._column)});
+        CompileError{std::format("Unexpected token '{}' at {}:{}", token.value(), token.line(), token.column())});
   }
 }
 
 Result<std::unique_ptr<ASTNode>> Parser::parseVariable(Token identifier) {
   spdlog::debug("Parsing variable");
   // If the passed token is not an identifier, consume the next token
-  if (identifier._type != Token::Type::IDENTIFIER) {
+  if (identifier != Token::Type::IDENTIFIER) {
     auto identifierResult = _lexer.nextToken();
     if (!identifierResult) {
       spdlog::error("{}", identifierResult.error().message());
@@ -222,7 +221,7 @@ Result<std::unique_ptr<ASTNode>> Parser::parseVariable(Token identifier) {
   }
 
   auto varNode = std::make_unique<VariableNode>();
-  varNode->name = identifier._value;
+  varNode->name = identifier.value();
   return varNode;
 }
 
@@ -234,9 +233,9 @@ Result<std::unique_ptr<ASTNode>> Parser::parseKernel() {
     return std::unexpected(CompileError{"Failed to consume '[' token in kernel"});
   }
   auto lbracketToken = *lbracketTokenResult;
-  if (lbracketToken._type != Token::Type::SYMBOL || lbracketToken._value != "[") {
+  if (lbracketToken != Token::Type::L_BRACKET) {
     return std::unexpected(
-        CompileError{std::format("Expected '[' at {}:{}", lbracketToken._line, lbracketToken._column)});
+        CompileError{std::format("Expected '[' at {}:{}", lbracketToken.line(), lbracketToken.column())});
   }
 
   auto kernelNode = std::make_unique<KernelNode>();
@@ -250,7 +249,7 @@ Result<std::unique_ptr<ASTNode>> Parser::parseKernel() {
     auto peekToken = *peekedtokenResult;
 
     // End of kernel
-    if (peekToken._type == Token::Type::SYMBOL && peekToken._value == "]") {
+    if (peekToken == Token::Type::R_BRACKET) {
       auto rbracket = _lexer.nextToken(); // consume ']'
       if (!rbracket) {
         spdlog::error("{}", rbracket.error().message());
@@ -261,9 +260,9 @@ Result<std::unique_ptr<ASTNode>> Parser::parseKernel() {
 
     // Expect a row: '[' NUMBER (',' NUMBER)* ']'
 
-    if (!(peekToken._type == Token::Type::SYMBOL && peekToken._value == "[")) {
+    if (!(peekToken == Token::Type::L_BRACKET)) {
       return std::unexpected(
-          CompileError{std::format("Expected '[' for kernel row at {}:{}", peekToken._line, peekToken._column)});
+          CompileError{std::format("Expected '[' for kernel row at {}:{}", peekToken.line(), peekToken.column())});
     }
 
     // consume inner '['
@@ -283,7 +282,7 @@ Result<std::unique_ptr<ASTNode>> Parser::parseKernel() {
       }
       auto innerToken = *innerTokenResult;
 
-      if (innerToken._type == Token::Type::SYMBOL && innerToken._value == "]") {
+      if (innerToken == Token::Type::R_BRACKET) {
         // empty row allowed? treat as end of row
         auto consumed = _lexer.nextToken(); // consume inner ']'
         if (!consumed) {
@@ -294,9 +293,9 @@ Result<std::unique_ptr<ASTNode>> Parser::parseKernel() {
       }
 
       // expect a number
-      if (innerToken._type != Token::Type::NUMBER) {
+      if (innerToken != Token::Type::NUMBER) {
         return std::unexpected(
-            CompileError{std::format("Expected number in kernel at {}:{}", innerToken._line, innerToken._column)});
+            CompileError{std::format("Expected number in kernel at {}:{}", innerToken.line(), innerToken.column())});
       }
       // consume number
       auto numTokenResult = _lexer.nextToken();
@@ -305,7 +304,7 @@ Result<std::unique_ptr<ASTNode>> Parser::parseKernel() {
         return std::unexpected(CompileError{"Failed to consume number token in kernel"});
       }
       auto numToken = *numTokenResult;
-      row.push_back(std::stod(numToken._value));
+      row.push_back(std::stod(numToken.value()));
 
       // after a number, expect ',' or ']'
       auto afterNumResult = _lexer.peekToken();
@@ -314,14 +313,14 @@ Result<std::unique_ptr<ASTNode>> Parser::parseKernel() {
         return std::unexpected(CompileError{"Failed to peek token in kernel"});
       }
       auto afterNum = *afterNumResult;
-      if (afterNum._type == Token::Type::SYMBOL && afterNum._value == ",") {
+      if (afterNum == Token::Type::COMMA) {
         auto commaTokenResult = _lexer.nextToken(); // consume comma
         if (!commaTokenResult) {
           spdlog::error("{}", commaTokenResult.error().message());
           return std::unexpected(CompileError{"Failed to consume comma token in kernel"});
         }
         continue; // continue reading numbers for this row
-      } else if (afterNum._type == Token::Type::SYMBOL && afterNum._value == "]") {
+      } else if (afterNum == Token::Type::R_BRACKET) {
         // consume closing inner ']'
         auto consumed = _lexer.nextToken();
         if (!consumed) {
@@ -330,8 +329,8 @@ Result<std::unique_ptr<ASTNode>> Parser::parseKernel() {
         }
         break;
       } else {
-        return std::unexpected(
-            CompileError{std::format("Expected ',' or ']' in kernel row at {}:{}", afterNum._line, afterNum._column)});
+        return std::unexpected(CompileError{
+            std::format("Expected ',' or ']' in kernel row at {}:{}", afterNum.line(), afterNum.column())});
       }
     }
 
@@ -345,14 +344,14 @@ Result<std::unique_ptr<ASTNode>> Parser::parseKernel() {
       return std::unexpected(CompileError{"Failed to peek token in kernel"});
     }
     auto next = *nextResult;
-    if (next._type == Token::Type::SYMBOL && next._value == ",") {
+    if (next == Token::Type::COMMA) {
       auto commaTokenResult = _lexer.nextToken(); // consume comma between rows
       if (!commaTokenResult) {
         spdlog::error("{}", commaTokenResult.error().message());
         return std::unexpected(CompileError{"Failed to consume comma token in kernel"});
       }
       // continue to next row
-    } else if (next._type == Token::Type::SYMBOL && next._value == "]") {
+    } else if (next == Token::Type::R_BRACKET) {
       // consume closing ']'
       auto r = _lexer.nextToken();
       if (!r) {
@@ -362,7 +361,7 @@ Result<std::unique_ptr<ASTNode>> Parser::parseKernel() {
       break;
     } else {
       return std::unexpected(
-          CompileError{std::format("Expected ',' or ']' after kernel row at {}:{}", next._line, next._column)});
+          CompileError{std::format("Expected ',' or ']' after kernel row at {}:{}", next.line(), next.column())});
     }
   }
 
@@ -387,12 +386,12 @@ Result<std::unique_ptr<ASTNode>> Parser::parseString() {
     return std::unexpected(CompileError{"Failed to consume string token"});
   }
   auto token = *tokenResult;
-  if (token._type != Token::Type::STRING) {
-    return std::unexpected(CompileError{std::format("Expected string at {}:{}", token._line, token._column)});
+  if (token != Token::Type::STRING) {
+    return std::unexpected(CompileError{std::format("Expected string at {}:{}", token.line(), token.column())});
   }
   auto strNode = std::make_unique<StringNode>();
   // TODO: Implement a compiler flag to let the user not expand tilde if it is not needed
-  strNode->value = utils::expandTilde(token._value);
+  strNode->value = utils::expandTilde(token.value());
   return strNode;
 }
 
@@ -404,18 +403,18 @@ Result<std::unique_ptr<ASTNode>> Parser::parseNumber() {
     return std::unexpected(CompileError{"Failed to consume number token"});
   }
   auto token = *tokenResult;
-  if (token._type != Token::Type::NUMBER) {
-    return std::unexpected(CompileError{std::format("Expected number at {}:{}", token._line, token._column)});
+  if (token != Token::Type::NUMBER) {
+    return std::unexpected(CompileError{std::format("Expected number at {}:{}", token.line(), token.column())});
   }
   auto numNode = std::make_unique<NumberNode>();
   try {
-    numNode->value = std::stod(token._value);
+    numNode->value = std::stod(token.value());
   } catch (const std::invalid_argument &) {
     return std::unexpected(
-        CompileError{std::format("Invalid double literal '{}' at {}:{}", token._value, token._line, token._column)});
+        CompileError{std::format("Invalid double literal '{}' at {}:{}", token.value(), token.line(), token.column())});
   } catch (const std::out_of_range &) {
     return std::unexpected(CompileError{
-        std::format("Double literal '{}' out of range at {}:{}", token._value, token._line, token._column)});
+        std::format("Double literal '{}' out of range at {}:{}", token.value(), token.line(), token.column())});
   }
   return numNode;
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -87,7 +87,7 @@ Result<std::unique_ptr<ASTNode>> Parser::parseStatement() {
   }
 }
 
-Result<std::unique_ptr<ASTNode>> Parser::parseFunctionDefinition(Token defToken) {
+Result<std::unique_ptr<ASTNode>> Parser::parseFunctionDefinition([[maybe_unused]] Token defToken) {
   auto nameTokenResult = _lexer.nextToken(); // consume function name
   if (!nameTokenResult) {
     spdlog::error("{}", nameTokenResult.error().message());
@@ -109,7 +109,11 @@ Result<std::unique_ptr<ASTNode>> Parser::parseFunctionDefinition(Token defToken)
     return std::unexpected(CompileError{"Expected '(' in function definition"});
   }
   auto tokenItter = _lexer.peekToken();
-  while (tokenItter != Token::Type::R_PAREN) {
+  if (!tokenItter) {
+    spdlog::error("{}", tokenItter.error().message());
+    return std::unexpected(CompileError{"Failed to peek token in function definition"});
+  }
+  while (tokenItter.value() != Token::Type::R_PAREN) {
     auto paramTokenResult = _lexer.nextToken(); // consume parameter -- expected name
     if (!paramTokenResult) {
       spdlog::error("{}", paramTokenResult.error().message());
@@ -142,7 +146,11 @@ Result<std::unique_ptr<ASTNode>> Parser::parseFunctionDefinition(Token defToken)
     }
     funcNode->parameters.push_back({paramToken.value(), typeToken.value()});
     tokenItter = _lexer.peekToken();
-    if (tokenItter == Token::Type::COMMA) {
+    if (!tokenItter) {
+      spdlog::error("{}", tokenItter.error().message());
+      return std::unexpected(CompileError{"Failed to peek token in function definition"});
+    }
+    if (tokenItter.value() == Token::Type::COMMA) {
       auto commaTokenResult = _lexer.nextToken(); // consume ','
       if (!commaTokenResult) {
         spdlog::error("{}", commaTokenResult.error().message());
@@ -178,7 +186,11 @@ Result<std::unique_ptr<ASTNode>> Parser::parseFunctionDefinition(Token defToken)
   }
 
   tokenItter = _lexer.peekToken();
-  while (tokenItter != Token::Type::R_BRACE) {
+  if (!tokenItter) {
+    spdlog::error("{}", tokenItter.error().message());
+    return std::unexpected(CompileError{"Failed to peek token in function definition"});
+  }
+  while (tokenItter.value() != Token::Type::R_BRACE) {
     auto stmtResult = parseStatement();
     if (!stmtResult) {
       spdlog::error("{}", stmtResult.error().message());
@@ -190,6 +202,10 @@ Result<std::unique_ptr<ASTNode>> Parser::parseFunctionDefinition(Token defToken)
     }
     funcNode->body.push_back(std::move(stmt));
     tokenItter = _lexer.peekToken();
+    if (!tokenItter) {
+      spdlog::error("{}", tokenItter.error().message());
+      return std::unexpected(CompileError{"Failed to peek token in function definition"});
+    }
   }
 
   auto rBraceTokenResult = _lexer.nextToken(); // consume '}'

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -72,12 +72,138 @@ Result<std::unique_ptr<ASTNode>> Parser::parseStatement() {
     return std::unexpected(CompileError{std::format("Unexpected token '{}' after identifier at {}:{}",
                                                     nextToken.value(), nextToken.line(), nextToken.column())});
 
+  } else if (token == Token::Type::KW_DEF) {
+    auto defTokenResult = _lexer.nextToken(); // consume 'def'
+    if (!defTokenResult) {
+      spdlog::error("{}", defTokenResult.error().message());
+      return std::unexpected(CompileError{"Failed to consume 'def' token"});
+    }
+    return parseFunctionDefinition(*defTokenResult);
   } else if (token == Token::Type::EOF_TOKEN) {
     return nullptr;
   } else {
     return std::unexpected(
         CompileError{std::format("Unexpected token '{}' at {}:{}", token.value(), token.line(), token.column())});
   }
+}
+
+Result<std::unique_ptr<ASTNode>> Parser::parseFunctionDefinition(Token defToken) {
+  auto nameTokenResult = _lexer.nextToken(); // consume function name
+  if (!nameTokenResult) {
+    spdlog::error("{}", nameTokenResult.error().message());
+    return std::unexpected(CompileError{"Failed to consume function name token"});
+  }
+  if (nameTokenResult->type() != Token::Type::IDENTIFIER) {
+    return std::unexpected(CompileError{std::format("Expected function name after 'def' at {}:{}",
+                                                    nameTokenResult->line(), nameTokenResult->column())});
+  }
+  auto funcNode = std::make_unique<FunctionNode>();
+  funcNode->name = nameTokenResult->value();
+  auto lParenTokenResult = _lexer.nextToken(); // consume '('
+  if (!lParenTokenResult) {
+    spdlog::error("{}", lParenTokenResult.error().message());
+    return std::unexpected(CompileError{"Failed to consume '(' token in function definition"});
+  }
+  auto lParenToken = *lParenTokenResult;
+  if (lParenToken.type() != Token::Type::L_PAREN) {
+    return std::unexpected(CompileError{"Expected '(' in function definition"});
+  }
+  auto tokenItter = _lexer.peekToken();
+  while (tokenItter != Token::Type::R_PAREN) {
+    auto paramTokenResult = _lexer.nextToken(); // consume parameter -- expected name
+    if (!paramTokenResult) {
+      spdlog::error("{}", paramTokenResult.error().message());
+      return std::unexpected(CompileError{"Failed to consume parameter token in function definition"});
+    }
+    auto paramToken = *paramTokenResult;
+    if (paramToken != Token::Type::IDENTIFIER) {
+      return std::unexpected(
+          CompileError{std::format("Expected parameter name at {}:{}", paramToken.line(), paramToken.column())});
+    }
+    auto colonTokenResult = _lexer.nextToken(); // consume ':'
+    if (!colonTokenResult) {
+      spdlog::error("{}", colonTokenResult.error().message());
+      return std::unexpected(CompileError{"Failed to consume ':' token in function definition"});
+    }
+    auto colonToken = *colonTokenResult;
+    if (colonToken != Token::Type::COLON) {
+      return std::unexpected(CompileError{
+          std::format("Expected ':' after parameter name at {}:{}", colonToken.line(), colonToken.column())});
+    }
+    auto typeTokenResult = _lexer.nextToken(); // consume type
+    if (!typeTokenResult) {
+      spdlog::error("{}", typeTokenResult.error().message());
+      return std::unexpected(CompileError{"Failed to consume type token in function definition"});
+    }
+    auto typeToken = *typeTokenResult;
+    if (typeToken != Token::Type::TYPE) {
+      return std::unexpected(
+          CompileError{std::format("Expected type after ':' at {}:{}", typeToken.line(), typeToken.column())});
+    }
+    funcNode->parameters.push_back({paramToken.value(), typeToken.value()});
+    tokenItter = _lexer.peekToken();
+    if (tokenItter == Token::Type::COMMA) {
+      auto commaTokenResult = _lexer.nextToken(); // consume ','
+      if (!commaTokenResult) {
+        spdlog::error("{}", commaTokenResult.error().message());
+        return std::unexpected(CompileError{"Failed to consume ',' token in function definition"});
+      }
+    }
+    tokenItter = _lexer.peekToken(); // could be ')' or another parameter
+    if (!tokenItter) {
+      spdlog::error("{}", tokenItter.error().message());
+      return std::unexpected(CompileError{"Failed to consume token in function definition"});
+    }
+  }
+  auto rParenTokenResult = _lexer.nextToken(); // consume ')'
+  if (!rParenTokenResult) {
+    spdlog::error("{}", rParenTokenResult.error().message());
+    return std::unexpected(CompileError{"Failed to consume ')' token in function definition"});
+  }
+  auto rParenToken = *rParenTokenResult;
+  if (rParenToken != Token::Type::R_PAREN) {
+    return std::unexpected(
+        CompileError{std::format("Expected ')' after parameters at {}:{}", rParenToken.line(), rParenToken.column())});
+  }
+
+  auto lBraceTokenResult = _lexer.nextToken(); // consume '{'
+  if (!lBraceTokenResult) {
+    spdlog::error("{}", lBraceTokenResult.error().message());
+    return std::unexpected(CompileError{"Failed to consume '{' token in function definition"});
+  }
+  auto lBraceToken = *lBraceTokenResult;
+  if (lBraceToken != Token::Type::L_BRACE) {
+    return std::unexpected(CompileError{
+        std::format("Expected '{{' after function signature at {}:{}", lBraceToken.line(), lBraceToken.column())});
+  }
+
+  tokenItter = _lexer.peekToken();
+  while (tokenItter != Token::Type::R_BRACE) {
+    auto stmtResult = parseStatement();
+    if (!stmtResult) {
+      spdlog::error("{}", stmtResult.error().message());
+      return std::unexpected(CompileError{"Failed to parse statement in function body"});
+    }
+    auto stmt = std::move(stmtResult.value());
+    if (!stmt) {
+      return std::unexpected(CompileError{"Unexpected end of function body"});
+    }
+    funcNode->body.push_back(std::move(stmt));
+    tokenItter = _lexer.peekToken();
+  }
+
+  auto rBraceTokenResult = _lexer.nextToken(); // consume '}'
+  if (!rBraceTokenResult) {
+    spdlog::error("{}", rBraceTokenResult.error().message());
+    return std::unexpected(CompileError{"Failed to consume '}' token in function definition"});
+  }
+  auto rBraceToken = *rBraceTokenResult;
+  if (rBraceToken != Token::Type::R_BRACE) {
+    return std::unexpected(CompileError{
+        std::format("Expected '}}' after function body at {}:{}", rBraceToken.line(), rBraceToken.column())});
+  }
+
+  return funcNode;
 }
 
 Result<std::unique_ptr<ASTNode>> Parser::parseAssignment(Token identifier) {

--- a/src/picceler_to_llvm_ir_pass.cpp
+++ b/src/picceler_to_llvm_ir_pass.cpp
@@ -58,9 +58,11 @@ struct StringConstConverter : public mlir::OpConversionPattern<StringConstOp> {
       mlir::OpBuilder::InsertionGuard guard(rewriter);
       rewriter.setInsertionPointToStart(module.getBody());
 
-      // Create the global string constant
-      rewriter.create<mlir::LLVM::GlobalOp>(loc, arrayType, /*isConstant=*/true, mlir::LLVM::Linkage::Internal, name,
-                                            rewriter.getStringAttr(bytes));
+      // Check if this global was already created by another function/statement
+      if (!module.lookupSymbol<mlir::LLVM::GlobalOp>(name)) {
+        rewriter.create<mlir::LLVM::GlobalOp>(loc, arrayType, /*isConstant=*/true, mlir::LLVM::Linkage::Internal, name,
+                                              rewriter.getStringAttr(bytes));
+      }
     }
 
     // Now create addressof and GEP at the use site (inside the function, where
@@ -113,12 +115,7 @@ struct PiccelerToLLVMIRPass : public impl::PiccelerToLLVMIRBase<PiccelerToLLVMIR
     target.addLegalOp<mlir::UnrealizedConversionCastOp>();
 
     target.addIllegalDialect<picceler::PiccelerDialect>();
-    target.addIllegalOp<picceler::StringConstOp>();
-
-    target.addDynamicallyLegalOp<mlir::func::FuncOp>(
-        [&](mlir::func::FuncOp op) { return converter.isSignatureLegal(op.getFunctionType()); });
-    target.addDynamicallyLegalOp<mlir::func::CallOp>([&](mlir::func::CallOp op) { return converter.isLegal(op); });
-    target.addDynamicallyLegalOp<mlir::func::ReturnOp>([&](mlir::func::ReturnOp op) { return converter.isLegal(op); });
+    target.addIllegalDialect<mlir::func::FuncDialect>();
 
     if (failed(applyPartialConversion(module, target, std::move(patterns)))) {
       signalPassFailure();

--- a/tests/unit/src/lexer_tests.cpp
+++ b/tests/unit/src/lexer_tests.cpp
@@ -20,7 +20,7 @@ TEST_F(LexerTest, EmptyInput) {
   auto tokens = tokensRes.value();
 
   ASSERT_EQ(tokens.size(), 1);
-  EXPECT_EQ(tokens[0]._type, picceler::Token::Type::EOF_TOKEN);
+  EXPECT_EQ(tokens[0].type(), picceler::Token::Type::EOF_TOKEN);
 }
 
 TEST_F(LexerTest, LoadImageStatement) {
@@ -37,25 +37,25 @@ TEST_F(LexerTest, LoadImageStatement) {
 
   ASSERT_GE(tokens.size(), 7); // img, =, load_image, (, "cat.jpg", ), EOF
 
-  EXPECT_EQ(tokens[0]._type, picceler::Token::Type::IDENTIFIER);
-  EXPECT_EQ(tokens[0]._value, "img");
+  EXPECT_EQ(tokens[0].type(), picceler::Token::Type::IDENTIFIER);
+  EXPECT_EQ(tokens[0].value(), "img");
 
-  EXPECT_EQ(tokens[1]._type, picceler::Token::Type::SYMBOL);
-  EXPECT_EQ(tokens[1]._value, "=");
+  EXPECT_EQ(tokens[1].type(), picceler::Token::Type::ASSIGN);
+  EXPECT_EQ(tokens[1].value(), "=");
 
-  EXPECT_EQ(tokens[2]._type, picceler::Token::Type::IDENTIFIER);
-  EXPECT_EQ(tokens[2]._value, "load_image");
+  EXPECT_EQ(tokens[2].type(), picceler::Token::Type::IDENTIFIER);
+  EXPECT_EQ(tokens[2].value(), "load_image");
 
-  EXPECT_EQ(tokens[3]._type, picceler::Token::Type::SYMBOL);
-  EXPECT_EQ(tokens[3]._value, "(");
+  EXPECT_EQ(tokens[3].type(), picceler::Token::Type::L_PAREN);
+  EXPECT_EQ(tokens[3].value(), "(");
 
-  EXPECT_EQ(tokens[4]._type, picceler::Token::Type::STRING);
-  EXPECT_EQ(tokens[4]._value, "cat.jpg");
+  EXPECT_EQ(tokens[4].type(), picceler::Token::Type::STRING);
+  EXPECT_EQ(tokens[4].value(), "cat.jpg");
 
-  EXPECT_EQ(tokens[5]._type, picceler::Token::Type::SYMBOL);
-  EXPECT_EQ(tokens[5]._value, ")");
+  EXPECT_EQ(tokens[5].type(), picceler::Token::Type::R_PAREN);
+  EXPECT_EQ(tokens[5].value(), ")");
 
-  EXPECT_EQ(tokens.back()._type, picceler::Token::Type::EOF_TOKEN);
+  EXPECT_EQ(tokens.back().type(), picceler::Token::Type::EOF_TOKEN);
 }
 
 TEST_F(LexerTest, NumbersParsing) {
@@ -70,8 +70,8 @@ TEST_F(LexerTest, NumbersParsing) {
 
   std::vector<std::string> numbers;
   for (const auto &t : tokens) {
-    if (t._type == picceler::Token::Type::NUMBER)
-      numbers.push_back(t._value);
+    if (t.type() == picceler::Token::Type::NUMBER)
+      numbers.push_back(t.value());
   }
 
   ASSERT_EQ(numbers.size(), 3);
@@ -94,12 +94,16 @@ TEST_F(LexerTest, KernelTokenSequence) {
   // ']', ']', EOF
   std::vector<std::string> seq;
   for (const auto &t : tokens) {
-    if (t._type == picceler::Token::Type::SYMBOL)
-      seq.push_back(t._value);
-    else if (t._type == picceler::Token::Type::NUMBER)
-      seq.push_back(t._value);
-    else if (t._type == picceler::Token::Type::IDENTIFIER)
-      seq.push_back(t._value);
+    if (t.type() == picceler::Token::Type::L_BRACKET)
+      seq.push_back(t.value());
+    else if (t.type() == picceler::Token::Type::R_BRACKET)
+      seq.push_back(t.value());
+    else if (t.type() == picceler::Token::Type::COMMA)
+      seq.push_back(t.value());
+    else if (t.type() == picceler::Token::Type::NUMBER)
+      seq.push_back(t.value());
+    else if (t.type() == picceler::Token::Type::IDENTIFIER)
+      seq.push_back(t.value());
   }
 
   std::vector<std::string> expected = {"k", "=", "[", "[", "1", ",", "2", "]", ",", "[", "3", ",", "4", "]", "]"};
@@ -125,12 +129,12 @@ TEST_F(LexerTest, IdentifiersAndUnderscores) {
   bool foundSomeFunction = false;
   bool foundPrivate = false;
   for (const auto &t : tokens) {
-    if (t._type == picceler::Token::Type::IDENTIFIER) {
-      if (t._value == "my_var")
+    if (t.type() == picceler::Token::Type::IDENTIFIER) {
+      if (t.value() == "my_var")
         foundMyVar = true;
-      if (t._value == "some_function")
+      if (t.value() == "some_function")
         foundSomeFunction = true;
-      if (t._value == "_private123")
+      if (t.value() == "_private123")
         foundPrivate = true;
     }
   }
@@ -148,14 +152,14 @@ TEST_F(LexerTest, StringParsingAndPeek) {
   if (!peekRes)
     FAIL() << peekRes.error().message();
   // peek should return first token (identifier 's') without consuming
-  EXPECT_EQ(peekRes->_type, picceler::Token::Type::IDENTIFIER);
-  EXPECT_EQ(peekRes->_value, "s");
+  EXPECT_EQ(peekRes->type(), picceler::Token::Type::IDENTIFIER);
+  EXPECT_EQ(peekRes->value(), "s");
 
   auto nextRes = lexer.nextToken();
   if (!nextRes)
     FAIL() << nextRes.error().message();
-  EXPECT_EQ(nextRes->_type, picceler::Token::Type::IDENTIFIER);
-  EXPECT_EQ(nextRes->_value, "s");
+  EXPECT_EQ(nextRes->type(), picceler::Token::Type::IDENTIFIER);
+  EXPECT_EQ(nextRes->value(), "s");
 
   // advance to string token
   // consume '=', identifier already consumed
@@ -165,8 +169,8 @@ TEST_F(LexerTest, StringParsingAndPeek) {
   auto strRes = lexer.nextToken();
   if (!strRes)
     FAIL() << strRes.error().message();
-  EXPECT_EQ(strRes->_type, picceler::Token::Type::STRING);
-  EXPECT_EQ(strRes->_value, "hello world");
+  EXPECT_EQ(strRes->type(), picceler::Token::Type::STRING);
+  EXPECT_EQ(strRes->value(), "hello world");
 }
 
 TEST_F(LexerTest, UnknownCharacterProducesUnknownToken) {
@@ -181,7 +185,7 @@ TEST_F(LexerTest, UnknownCharacterProducesUnknownToken) {
 
   bool foundUnknown = false;
   for (const auto &t : tokens) {
-    if (t._type == picceler::Token::Type::UNKNOWN)
+    if (t.type() == picceler::Token::Type::UNKNOWN)
       foundUnknown = true;
   }
   EXPECT_TRUE(foundUnknown);

--- a/tests/unit/src/lexer_tests.cpp
+++ b/tests/unit/src/lexer_tests.cpp
@@ -104,6 +104,8 @@ TEST_F(LexerTest, KernelTokenSequence) {
       seq.push_back(t.value());
     else if (t.type() == picceler::Token::Type::IDENTIFIER)
       seq.push_back(t.value());
+    else if (t.type() == picceler::Token::Type::ASSIGN)
+      seq.push_back(t.value());
   }
 
   std::vector<std::string> expected = {"k", "=", "[", "[", "1", ",", "2", "]", ",", "[", "3", ",", "4", "]", "]"};


### PR DESCRIPTION
This PR is a big milestone in the compiler.

First, it adds support for user defined functions, lowering to `func.func` instances, able to have parameters in the function signature with mandatory type annotation.
Second, it enhances the lexer system and makes everything much clearer to work with when dealing with tokens
Third, it adds support for scoped variable tables so that different function can define the same named variables, remaining local to their scope. Finding variables is reverse iterating through the scope stack and returns the first appearence, that is most local.

There are no tests that are added by this PR as LIT infrastructure works on passes and user function generation works currently in the AST -> MLIR by the MLIRGen class, which is not covered by unit tests. Will probably need to introduce tests for this