### PR TITLE
Fix clang-tidy warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,10 +1,31 @@
 HeaderFilterRegex: '.*picceler/.*'
-ExcludeHeaderFilterRegex: '.*/build/tablegen/.*'
+ExcludeHeaderFilterRegex: '.*/build/.*'
 
-Checks: 'cppcoreguidelines-*,readability-identifier-naming'
-
+Checks: >-
+  -*,
+  bugprone-*,
+  performance-*,
+  misc-definitions-in-headers,
+  misc-unconventional-assign-operator,
+  readability-identifier-naming,
+  -bugprone-easily-swappable-parameters
 CheckOptions:
+  # --- Class / Struct Naming ---
   - key: readability-identifier-naming.ClassCase
     value: CamelCase
+  - key: readability-identifier-naming.StructCase
+    value: CamelCase
+
+  # --- Function Naming ---
   - key: readability-identifier-naming.FunctionCase
     value: camelBack
+
+  # --- Local Variables ---
+  - key: readability-identifier-naming.VariableCase
+    value: camelBack
+
+  # --- Member Variables (Enforce private/protected prefix or suffix) ---
+  - key: readability-identifier-naming.MemberCase
+    value: camelBack
+  - key: readability-identifier-naming.MemberPrefix
+    value: '_'

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "C_Cpp.default.compileCommands": "${workspaceFolder}/build/compile_commands.json"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "C_Cpp.default.compileCommands": "${workspaceFolder}/build/compile_commands.json"
-}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,12 @@ if (ENABLE_CLANG_TIDY)
     find_program(CLANG_TIDY_EXE NAMES clang-tidy)
     if(CLANG_TIDY_EXE)
         message(STATUS "clang-tidy found: ${CLANG_TIDY_EXE}")
-        set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_EXE};-extra-arg=-std=c++${CMAKE_CXX_STANDARD}")
+        set(CMAKE_CXX_CLANG_TIDY 
+            "${CLANG_TIDY_EXE}"
+            "-warnings-as-errors=*"
+            "-extra-arg=-std=c++${CMAKE_CXX_STANDARD}"
+            "-extra-arg=-Werror"
+        )
     else()
         message(WARNING "clang-tidy option enabled but clang-tidy executable not found!")
     endif()

--- a/include/ast.h
+++ b/include/ast.h
@@ -4,18 +4,12 @@
 #include <string>
 #include <optional>
 #include <memory>
-
-#include "lexer.h"
+#include <ranges>
 
 namespace picceler {
 
-template <typename T> std::vector<T *> getRawPointers(const std::vector<std::unique_ptr<T>> &vec) {
-  std::vector<T *> rawPointers;
-  rawPointers.reserve(vec.size());
-  for (const auto &item : vec) {
-    rawPointers.push_back(item.get());
-  }
-  return rawPointers;
+template <typename T> auto getRawPointers(const std::vector<std::unique_ptr<T>> &vec) {
+  return vec | std::views::transform([](const std::unique_ptr<T> &ptr) { return ptr.get(); });
 }
 
 /**
@@ -40,9 +34,11 @@ public:
 
 class ModuleNode : public ASTNode {
 public:
-  std::vector<ASTNode *> statements() const { return getRawPointers(_statements); }
-  std::vector<std::unique_ptr<ASTNode>> &mutableStatements() { return _statements; }
+  auto statements() const { return getRawPointers(_statements); }
 
+  void normalizeTopLevelStatements();
+
+  bool wrapTopLevelStatementsInMain();
   void addStatement(std::unique_ptr<ASTNode> statement) { _statements.push_back(std::move(statement)); }
 
   std::string toString() const override;
@@ -60,7 +56,7 @@ public:
 
   const std::string &name() const { return _name; }
   const auto &parameters() const { return _parameters; }
-  std::vector<ASTNode *> body() const { return getRawPointers(_body); }
+  auto body() const { return getRawPointers(_body); }
 
   void addParameter(const std::string &paramName, const std::string &paramType) {
     _parameters.emplace_back(paramName, paramType);
@@ -150,7 +146,7 @@ public:
   CallNode(std::string callee) : _callee(std::move(callee)), _arguments() {}
 
   const std::string &callee() const { return _callee; }
-  std::vector<ASTNode *> arguments() const { return getRawPointers(_arguments); }
+  auto arguments() const { return getRawPointers(_arguments); }
 
   void addArgument(std::unique_ptr<ASTNode> arg) { _arguments.push_back(std::move(arg)); }
 

--- a/include/ast.h
+++ b/include/ast.h
@@ -9,10 +9,20 @@
 
 namespace picceler {
 
+template <typename T> std::vector<T *> getRawPointers(const std::vector<std::unique_ptr<T>> &vec) {
+  std::vector<T *> rawPointers;
+  rawPointers.reserve(vec.size());
+  for (const auto &item : vec) {
+    rawPointers.push_back(item.get());
+  }
+  return rawPointers;
+}
+
 /**
  * @brief Abstract Syntax Tree (AST) node base class.
  */
-struct ASTNode {
+class ASTNode {
+public:
   ASTNode() = default;
   virtual ~ASTNode() = default;
 
@@ -28,71 +38,143 @@ struct ASTNode {
  * @brief AST node for the entire module.
  */
 
-struct ModuleNode : public ASTNode {
-  std::vector<std::unique_ptr<ASTNode>> statements;
+class ModuleNode : public ASTNode {
+public:
+  std::vector<ASTNode *> statements() const { return getRawPointers(_statements); }
+  std::vector<std::unique_ptr<ASTNode>> &mutableStatements() { return _statements; }
+
+  void addStatement(std::unique_ptr<ASTNode> statement) { _statements.push_back(std::move(statement)); }
+
   std::string toString() const override;
+
+private:
+  std::vector<std::unique_ptr<ASTNode>> _statements;
 };
 
 /**
  * @brief AST node for function definitions.
  */
-struct FunctionNode : public ASTNode {
-  std::string name;
-  std::vector<std::pair<std::string, std::string>> parameters;
-  std::vector<std::unique_ptr<ASTNode>> body;
+class FunctionNode : public ASTNode {
+public:
+  FunctionNode(std::string name) : _name(std::move(name)) {}
+
+  const std::string &name() const { return _name; }
+  const auto &parameters() const { return _parameters; }
+  std::vector<ASTNode *> body() const { return getRawPointers(_body); }
+
+  void addParameter(const std::string &paramName, const std::string &paramType) {
+    _parameters.emplace_back(paramName, paramType);
+  }
+
+  void addBodyStatement(std::unique_ptr<ASTNode> statement) { _body.push_back(std::move(statement)); }
+
   std::string toString() const override;
+
+private:
+  std::string _name;
+  std::vector<std::pair<std::string, std::string>> _parameters;
+  std::vector<std::unique_ptr<ASTNode>> _body;
 };
 
 /**
  * @brief AST node for variable references.
  */
-struct VariableNode : public ASTNode {
-  std::string name;
-  std::optional<std::string> type; // optional type annotation
+class VariableNode : public ASTNode {
+public:
+  VariableNode(std::string name, std::optional<std::string> type = std::nullopt)
+      : _name(std::move(name)), _type(std::move(type)) {}
+
+  const std::string &name() const { return _name; }
+  const std::optional<std::string> &type() const { return _type; }
+
   std::string toString() const override;
+
+private:
+  std::string _name;
+  std::optional<std::string> _type; // optional type annotation
 };
 
 /**
  * @brief AST node for string literals.
  */
-struct StringNode : public ASTNode {
-  std::string value;
+class StringNode : public ASTNode {
+public:
+  StringNode(std::string value) : _value(std::move(value)) {}
+
+  const std::string &value() const { return _value; }
+
   std::string toString() const override;
+
+private:
+  std::string _value;
 };
 
 /**
  * @brief AST node for numeric literals.
  */
-struct NumberNode : public ASTNode {
-  double value;
+class NumberNode : public ASTNode {
+public:
+  NumberNode(double value) : _value(value) {}
+
+  double value() const { return _value; }
+
   std::string toString() const override;
+
+private:
+  double _value;
 };
 
 /**
  * @brief AST node for assignment statements.
  */
-struct AssignmentNode : public ASTNode {
-  std::unique_ptr<VariableNode> lhs;
-  std::unique_ptr<ASTNode> rhs;
+class AssignmentNode : public ASTNode {
+public:
+  AssignmentNode(std::unique_ptr<VariableNode> lhs, std::unique_ptr<ASTNode> rhs)
+      : _lhs(std::move(lhs)), _rhs(std::move(rhs)) {}
+
+  VariableNode *lhs() const { return _lhs.get(); }
+  ASTNode *rhs() const { return _rhs.get(); }
+
   std::string toString() const override;
+
+private:
+  std::unique_ptr<VariableNode> _lhs;
+  std::unique_ptr<ASTNode> _rhs;
 };
 
 /**
  * @brief AST node for function calls.
  */
-struct CallNode : public ASTNode {
-  std::string callee;
-  std::vector<std::unique_ptr<ASTNode>> arguments;
+class CallNode : public ASTNode {
+public:
+  CallNode(std::string callee) : _callee(std::move(callee)), _arguments() {}
+
+  const std::string &callee() const { return _callee; }
+  std::vector<ASTNode *> arguments() const { return getRawPointers(_arguments); }
+
+  void addArgument(std::unique_ptr<ASTNode> arg) { _arguments.push_back(std::move(arg)); }
+
   std::string toString() const override;
+
+private:
+  std::string _callee;
+  std::vector<std::unique_ptr<ASTNode>> _arguments;
 };
 
 /**
  * @brief AST node for kernel definitions.
  */
 
-struct KernelNode : public ASTNode {
-  std::vector<std::vector<double>> rows;
+class KernelNode : public ASTNode {
+public:
+  const std::vector<std::vector<double>> &rows() const { return _rows; }
+
+  void addRow(const std::vector<double> &row) { _rows.push_back(row); }
+
   std::string toString() const override;
+
+private:
+  std::vector<std::vector<double>> _rows;
 };
 
 } // namespace picceler

--- a/include/channels.h
+++ b/include/channels.h
@@ -1,7 +1,10 @@
 #pragma once
+
+#include <cstdint>
+
 namespace picceler {
 
-enum class Channel : int {
+enum class Channel : uint8_t {
   R = 0,
   G = 1,
   B = 2,

--- a/include/compiler.h
+++ b/include/compiler.h
@@ -26,8 +26,8 @@ namespace picceler {
  */
 class CLIOptions {
 public:
-  std::string inputFile;
-  std::string outputFile;
+  std::string _inputFile;
+  std::string _outputFile;
 };
 
 /**

--- a/include/compiler.h
+++ b/include/compiler.h
@@ -1,17 +1,7 @@
 #pragma once
 
-#include <format>
-#include <iostream>
-
 #include "CLI/CLI.hpp"
-#include "spdlog/spdlog.h"
-#include "mlir/Dialect/Arith/IR/Arith.h"
-#include "mlir/Dialect/Func/IR/FuncOps.h"
-#include "mlir/IR/Builders.h"
-#include "mlir/IR/BuiltinOps.h"
-#include "mlir/IR/Dialect.h"
 #include "mlir/Pass/PassManager.h"
-#include "mlir/Pass/Pass.h"
 #include "llvm/IR/Module.h"
 
 #include "dialect.h"

--- a/include/error.h
+++ b/include/error.h
@@ -6,16 +6,28 @@
 
 namespace picceler {
 
+/** @brief Struct to hold location information. */
+class Location {
+public:
+  Location() : _line(0), _column(0) {}
+  explicit Location(std::pair<size_t, size_t> line_column) : _line(line_column.first), _column(line_column.second) {}
+
+  size_t line() const { return _line; }
+  size_t column() const { return _column; }
+
+private:
+  size_t _line = 0;
+  size_t _column = 0;
+};
+
 /**
  * @brief Struct to hold compilation error information.
  */
 struct CompileError {
 
-  CompileError() : _message("Empty message! If this isn't a test, debug this."), _line(0), _column(0) {}
-  explicit CompileError(std::string &&string, size_t line = 0, size_t column = 0)
-      : _message(std::move(string)), _line(line), _column(column) {}
-  explicit CompileError(const std::string &string, size_t line = 0, size_t column = 0)
-      : _message(string), _line(line), _column(column) {}
+  CompileError() : _message("Empty message! If this isn't a test, debug this."), _location() {}
+  explicit CompileError(std::string string, Location location = {})
+      : _message(std::move(string)), _location(location) {}
 
   CompileError(const CompileError &) = default;
   CompileError(CompileError &&) = default;
@@ -24,19 +36,18 @@ struct CompileError {
   CompileError &operator=(CompileError &&) = default;
 
   std::string _message;
-  size_t _line;
-  size_t _column;
+  Location _location;
 
   //   const std::string &message() const { return _message; }
-  size_t line() const { return _line; }
-  size_t column() const { return _column; }
+  size_t line() const { return _location.line(); }
+  size_t column() const { return _location.column(); }
 
   std::string message() const {
-    if (_line == 0 && _column == 0) {
+    if (_location.line() == 0 && _location.column() == 0) {
       return std::format("CompilerError: {}", _message);
     }
 
-    return std::format("[line {}:{}] CompilerError: {}", _line, _column, _message);
+    return std::format("[line {}:{}] CompilerError: {}", _location.line(), _location.column(), _message);
   }
 };
 

--- a/include/error.h
+++ b/include/error.h
@@ -11,6 +11,7 @@ class Location {
 public:
   Location() : _line(0), _column(0) {}
   explicit Location(std::pair<size_t, size_t> line_column) : _line(line_column.first), _column(line_column.second) {}
+  explicit Location(size_t line, size_t column) : _line(line), _column(column) {}
 
   size_t line() const { return _line; }
   size_t column() const { return _column; }

--- a/include/image_access_helper.h
+++ b/include/image_access_helper.h
@@ -17,11 +17,8 @@ namespace picceler {
  *   unsigned char *_data; // Offset 8
  * };
  */
-struct ImageAccessHelper {
-  mlir::Value structPtr; // !llvm.ptr (Opaque pointer to the Image struct)
-  mlir::OpBuilder &builder;
-  mlir::Location loc;
-
+class ImageAccessHelper {
+public:
   ImageAccessHelper(mlir::Value ptr, mlir::OpBuilder &b, mlir::Location l);
 
   /**
@@ -58,6 +55,11 @@ struct ImageAccessHelper {
    * @return MLIR value representing the data pointer.
    */
   mlir::Value getDataPtr();
+
+private:
+  mlir::Value _structPtr; // !llvm.ptr (Opaque pointer to the Image struct)
+  mlir::OpBuilder &_builder;
+  mlir::Location _loc;
 };
 
 } // namespace picceler

--- a/include/image_access_helper.h
+++ b/include/image_access_helper.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/Location.h"
 #include "mlir/IR/Value.h"

--- a/include/lexer.h
+++ b/include/lexer.h
@@ -14,7 +14,6 @@
 #include <string>
 #include <utility>
 #include <vector>
-#include <expected>
 
 #include "error.h"
 

--- a/include/lexer.h
+++ b/include/lexer.h
@@ -90,7 +90,7 @@ struct Token {
   const std::string &value() const { return _value; }
   size_t line() const { return _location.line(); }
   size_t column() const { return _location.column(); }
-
+  Location location() const { return _location; }
   /*
    * @brief Compares a token to a token type for easy checking in parsing.
    * @param lhs The token to compare.

--- a/include/lexer.h
+++ b/include/lexer.h
@@ -26,7 +26,7 @@ namespace picceler {
  */
 struct Token {
   /** @brief The type of the token. */
-  enum class Type : size_t {
+  enum class Type : uint8_t {
     IDENTIFIER, // Represents identifiers (user defined names)
     NUMBER,     // Represents numeric literals (e.g., integers, floats)
     STRING,     // Represents string literals
@@ -47,21 +47,18 @@ struct Token {
     UNKNOWN     // Represents unknown tokens
   };
 
-  Token() : _type(Type::UNKNOWN), _value(""), _line(0), _column(0) {}
+  Token() : _type(Type::UNKNOWN), _value(""), _location() {}
 
-  Token(Type type, std::string value, size_t line, size_t column)
-      : _type(type), _value(std::move(value)), _line(line), _column(column) {}
+  Token(Type type, std::string value, Location location) : _type(type), _value(std::move(value)), _location(location) {}
 
-  Token(const Token &other) : _type(other._type), _value(other._value), _line(other._line), _column(other._column) {}
-  Token(Token &&other) noexcept
-      : _type(other._type), _value(std::move(other._value)), _line(other._line), _column(other._column) {}
+  Token(const Token &other) : _type(other._type), _value(other._value), _location(other._location) {}
+  Token(Token &&other) noexcept : _type(other._type), _value(std::move(other._value)), _location(other._location) {}
   ~Token() = default;
   Token &operator=(const Token &other) {
     if (this != &other) {
       _type = other._type;
       _value = other._value;
-      _line = other._line;
-      _column = other._column;
+      _location = other._location;
     }
     return *this;
   }
@@ -69,8 +66,7 @@ struct Token {
     if (this != &other) {
       _type = other._type;
       _value = std::move(other._value);
-      _line = other._line;
-      _column = other._column;
+      _location = other._location;
     }
     return *this;
   }
@@ -86,13 +82,14 @@ struct Token {
    * @return The string representation of the token.
    */
   std::string toString() const {
-    return std::format("Token(type: {}, value: '{}', line: {}, column: {})", typeToString(), _value, _line, _column);
+    return std::format("Token(type: {}, value: '{}', line: {}, column: {})", typeToString(), _value, _location.line(),
+                       _location.column());
   }
 
   Type type() const { return _type; }
   const std::string &value() const { return _value; }
-  size_t line() const { return _line; }
-  size_t column() const { return _column; }
+  size_t line() const { return _location.line(); }
+  size_t column() const { return _location.column(); }
 
   /*
    * @brief Compares a token to a token type for easy checking in parsing.
@@ -105,8 +102,7 @@ struct Token {
 private:
   Type _type;
   std::string _value;
-  size_t _line;
-  size_t _column;
+  Location _location;
 };
 
 /**

--- a/include/mlir_gen.h
+++ b/include/mlir_gen.h
@@ -5,13 +5,10 @@
 #include <string>
 #include <vector>
 
-#include "mlir/Dialect/Arith/IR/Arith.h"
-#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/Pass/PassManager.h"
-#include "mlir/Pass/Pass.h"
 
 #include "dialect.h"
 #include "types.h"
@@ -46,14 +43,6 @@ public:
   mlir::ModuleOp generate(ModuleNode *root);
 
 private:
-  /**
-   * @brief Normalizes the AST by processing all top-level statements in the module and assign to main if not found.
-   * @param module The MLIR module operation.
-   * @param root The root node of the AST.
-   * @return True if normalization is successful, false otherwise.
-   */
-  bool normalizeASTMain(mlir::ModuleOp module, ModuleNode *root);
-
   /**
    * @brief Declares user-defined functions in the MLIR module.
    * @param module The MLIR module operation.

--- a/include/mlir_gen.h
+++ b/include/mlir_gen.h
@@ -36,7 +36,7 @@ public:
   MLIRGen &operator=(const MLIRGen &) = default;
   MLIRGen(MLIRGen &&) = default;
   MLIRGen &operator=(MLIRGen &&) = default;
-  ~MLIRGen();
+  ~MLIRGen() noexcept;
 
   /**
    * @brief Generates MLIR code from the given AST root node.
@@ -98,7 +98,7 @@ private:
   /**
    * @brief Exits the current scope.
    */
-  void exitScope();
+  void exitScope() noexcept;
 
   /**
    * @brief Emits MLIR code for a given AST node.

--- a/include/parser.h
+++ b/include/parser.h
@@ -52,10 +52,10 @@ private:
    */
   Result<std::unique_ptr<ASTNode>> parseStatement();
   Result<std::unique_ptr<ASTNode>> parseExpression();
-  Result<std::unique_ptr<ASTNode>> parseFunctionDefinition(Token defToken);
-  Result<std::unique_ptr<ASTNode>> parseAssignment(Token identifier);
-  Result<std::unique_ptr<ASTNode>> parseCall(Token identifier);
-  Result<std::unique_ptr<ASTNode>> parseVariable(Token identifier = Token{Token::Type::UNKNOWN, "", 0, 0});
+  Result<std::unique_ptr<ASTNode>> parseFunctionDefinition(const Token &defToken);
+  Result<std::unique_ptr<ASTNode>> parseAssignment(const Token &identifier);
+  Result<std::unique_ptr<ASTNode>> parseCall(const Token &identifier);
+  Result<std::unique_ptr<ASTNode>> parseVariable(const Token &identifier = Token{Token::Type::UNKNOWN, "", {}});
   Result<std::unique_ptr<ASTNode>> parseKernel();
   Result<std::unique_ptr<ASTNode>> parseString();
   Result<std::unique_ptr<ASTNode>> parseNumber();

--- a/include/pass_manager.h
+++ b/include/pass_manager.h
@@ -6,10 +6,9 @@
 
 #include "mlir/Pass/PassManager.h"
 #include "llvm/Support/raw_ostream.h"
-#include "llvm/Support/FileSystem.h"
 #include "mlir/Pass/PassInstrumentation.h"
-
-#include "passes.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/IR/BuiltinOps.h"
 
 namespace picceler {
 

--- a/include/passes.h
+++ b/include/passes.h
@@ -3,7 +3,6 @@
 #include <memory>
 
 #include "mlir/Pass/Pass.h"
-#include "mlir/IR/BuiltinOps.h"
 
 namespace picceler {
 

--- a/include/utils.h
+++ b/include/utils.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include <filesystem>
 #include <string>
-#include <cstdlib>
 
 #ifndef _WIN32
 #include <unistd.h>
@@ -28,6 +26,6 @@ namespace picceler::utils {
  * @return A string where a leading '~' has been replaced by the user's home
  *         directory, or the original inputPath if no expansion is performed.
  */
-std::string expandTilde(const std::string& inputPath);
+std::string expandTilde(const std::string &inputPath);
 
 } // namespace picceler::utils

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.20)
 
 set(RUNTIME_LIB_NAME "PiccelerRuntime")
 
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 23)
 
 find_package(OpenCV REQUIRED)
 find_package(spdlog REQUIRED)

--- a/lib/src/image.cpp
+++ b/lib/src/image.cpp
@@ -1,23 +1,24 @@
 #include "image.h"
-
 #include "spdlog/spdlog.h"
+
+#include <print>
 
 namespace picceler {
 
 void internalDebugImage(const picceler::Image &image, const std::string &caller) {
-  std::cout << "[Runtime Debug from " << caller << "]\n"
-            << "  Addr of struct: " << &image << "\n"
-            << "  Width:    " << image._width << "\n"
-            << "  Height:   " << image._height << "\n"
-            << "  Data Ptr: " << (void *)image._data << std::endl;
+  spdlog::info("[Runtime Debug from {}]\n"
+               "  Addr of struct: {}\n"
+               "  Width:    {}\n"
+               "  Height:   {}\n"
+               "  Data Ptr: {}",
+               caller, (void *)&image, image._width, image._height, (void *)image._data);
 
   if (image._data != nullptr && image._width > 0 && image._height > 0) {
-    std::cout << "  First 4 bytes (RGBA): " << (int)image._data[0] << " " << (int)image._data[1] << " "
-              << (int)image._data[2] << " " << (int)image._data[3] << std::endl;
-  } else {
-    std::cout << "  WARNING: Image metadata or pointer is INVALID!" << std::endl;
+    spdlog::info("\tFirst 4 pixels (RGBA): {} {} {} {}", (int)image._data[0], (int)image._data[1], (int)image._data[2],
+                 (int)image._data[3]);
   }
-  std::cout << "--------------------------------------" << std::endl;
+  spdlog::info("\tWidth: {}, Height: {}, Data Ptr: {}", image._width, image._height, (void *)image._data);
+  spdlog::info("--------------------------------------");
 }
 
 Image *loadImage(const std::string &filename) {
@@ -45,7 +46,7 @@ Image *loadImage(const std::string &filename) {
 
 void saveImage(const Image &image, const std::string &filename) {
   internalDebugImage(image, "saveImage");
-  cv::Mat rgbaMat(image._height, image._width, CV_8UC4, image._data);
+  cv::Mat rgbaMat(static_cast<int>(image._height), static_cast<int>(image._width), CV_8UC4, image._data);
 
   cv::Mat bgrMat;
   cv::cvtColor(rgbaMat, bgrMat, cv::COLOR_RGBA2BGR);
@@ -58,7 +59,7 @@ void saveImage(const Image &image, const std::string &filename) {
 
 void showImage(const Image &image) {
   internalDebugImage(image, "showImage");
-  cv::Mat rgbaMat(image._height, image._width, CV_8UC4, image._data);
+  cv::Mat rgbaMat(static_cast<int>(image._height), static_cast<int>(image._width), CV_8UC4, image._data);
 
   cv::Mat bgrMat;
   cv::cvtColor(rgbaMat, bgrMat, cv::COLOR_RGBA2BGR);

--- a/lib/src/image.cpp
+++ b/lib/src/image.cpp
@@ -1,8 +1,6 @@
 #include "image.h"
 #include "spdlog/spdlog.h"
 
-#include <print>
-
 namespace picceler {
 
 void internalDebugImage(const picceler::Image &image, const std::string &caller) {

--- a/lib/src/runtime.cpp
+++ b/lib/src/runtime.cpp
@@ -34,7 +34,7 @@ picceler::Image *piccelerCreateImage(uint32_t width, uint32_t height) {
   newImage->_width = width;
   newImage->_height = height;
   constexpr auto channels = 4;
-  newImage->_data = new unsigned char[static_cast<size_t>(width * height * channels)];
+  newImage->_data = new unsigned char[static_cast<size_t>(width) * height * channels];
 
   return newImage;
 }

--- a/lib/src/runtime.cpp
+++ b/lib/src/runtime.cpp
@@ -34,7 +34,7 @@ picceler::Image *piccelerCreateImage(uint32_t width, uint32_t height) {
   newImage->_width = width;
   newImage->_height = height;
   constexpr auto channels = 4;
-  newImage->_data = new unsigned char[width * height * channels];
+  newImage->_data = new unsigned char[static_cast<size_t>(width * height * channels)];
 
   return newImage;
 }

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -4,49 +4,49 @@
 
 namespace picceler {
 
-std::string ModuleNode::toString() const { return std::format("Module: {} statements", statements.size()); }
+std::string ModuleNode::toString() const { return std::format("Module: {} statements", statements().size()); }
 
 std::string FunctionNode::toString() const {
   std::string params;
-  for (const auto &param : parameters) {
+  for (const auto &param : parameters()) {
     if (!params.empty()) {
       params += ", ";
     }
     params += std::format("{}: {}", param.first, param.second);
   }
   std::string statements;
-  if (!body.empty()) {
-    for (const auto &statement : body) {
+  if (!body().empty()) {
+    for (const auto &statement : body()) {
       statements += "\t" + statement->toString() + "\n";
     }
   }
-  return std::format("Function:[{}({})] {{\n{}}}", name, params, statements);
+  return std::format("Function:[{}({})] {{\n{}}}", name(), params, statements);
 }
 
-std::string VariableNode::toString() const { return std::format("Variable:[{}]", name); }
+std::string VariableNode::toString() const { return std::format("Variable:[{}]", name()); }
 
-std::string StringNode::toString() const { return std::format("String:[{}]", value); }
+std::string StringNode::toString() const { return std::format("String:[{}]", value()); }
 
-std::string NumberNode::toString() const { return std::format("Number:[{}]", value); }
+std::string NumberNode::toString() const { return std::format("Number:[{}]", value()); }
 
 std::string AssignmentNode::toString() const {
-  return std::format("Assignment:[{} = {}]", lhs->toString(), rhs->toString());
+  return std::format("Assignment:[{} = {}]", lhs()->toString(), rhs()->toString());
 }
 
 std::string CallNode::toString() const {
   std::string args;
-  for (const auto &arg : arguments) {
+  for (const auto &arg : arguments()) {
     if (!args.empty()) {
       args += ", ";
     }
     args += arg->toString();
   }
-  return std::format("Call:[{}({})]", callee, args);
+  return std::format("Call:[{}({})]", callee(), args);
 }
 
 std::string KernelNode::toString() const {
-  std::string repr = std::format("Kernel({}x{}):[", rows.size(), rows.empty() ? 0 : rows[0].size());
-  for (const auto &row : rows) {
+  std::string repr = std::format("Kernel({}x{}):[", rows().size(), rows().empty() ? 0 : rows()[0].size());
+  for (const auto &row : rows()) {
     repr += " [";
     for (size_t i = 0; i < row.size(); ++i) {
       repr += std::to_string(row[i]);

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -1,10 +1,69 @@
 #include <format>
+#include "spdlog/spdlog.h"
 
 #include "ast.h"
 
 namespace picceler {
 
 std::string ModuleNode::toString() const { return std::format("Module: {} statements", statements().size()); }
+
+void ModuleNode::normalizeTopLevelStatements() {
+  spdlog::info("Printing all statements in the AST:\n");
+  for (auto stmt : statements()) {
+    spdlog::info("{}\n", stmt->toString());
+  }
+  auto modified = wrapTopLevelStatementsInMain();
+  if (modified) {
+    spdlog::info("AST normalization modified the graph. Final AST:\n");
+    for (auto stmt : statements()) {
+      spdlog::info("{}\n", stmt->toString());
+    }
+  }
+}
+
+bool ModuleNode::wrapTopLevelStatementsInMain() {
+  bool hasMain = false;
+  bool onlyFunctions = true;
+
+  for (auto stmt : statements()) {
+    if (auto funcNode = dynamic_cast<FunctionNode *>(stmt)) {
+      if (funcNode->name() == "main") {
+        hasMain = true;
+      }
+    } else {
+      onlyFunctions = false;
+    }
+  }
+
+  if (!hasMain) {
+    if (!onlyFunctions) {
+      spdlog::warn("No 'main' functions found, implicit 'main' will be generated to wrap the top-level statements");
+      auto mainFunc = std::make_unique<FunctionNode>("main");
+      for (auto &stmt : _statements) {
+        auto stmtPtr = stmt.get();
+        if (!dynamic_cast<FunctionNode *>(stmtPtr)) {
+          mainFunc->addBodyStatement(std::move(stmt));
+        }
+      }
+      _statements.erase(std::remove_if(_statements.begin(), _statements.end(),
+                                       [&](const std::unique_ptr<ASTNode> &stmt) {
+                                         return !dynamic_cast<FunctionNode *>(stmt.get());
+                                       }),
+                        _statements.end());
+      _statements.push_back(std::move(mainFunc));
+    } else {
+      spdlog::error("No 'main' function found and no top-level statements to wrap.");
+      return false;
+    }
+  } else {
+    if (!onlyFunctions) {
+      spdlog::warn("Found 'main' function, but also found top-level statements. Not allowed.");
+      return false;
+    }
+  }
+
+  return true;
+}
 
 std::string FunctionNode::toString() const {
   std::string params;

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -1,8 +1,9 @@
-#include <format>
-#include "spdlog/spdlog.h"
-
 #include "ast.h"
 
+#include "spdlog/spdlog.h"
+
+#include <format>
+#include <algorithm>
 namespace picceler {
 
 std::string ModuleNode::toString() const { return std::format("Module: {} statements", statements().size()); }

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -27,8 +27,8 @@ namespace picceler {
 Compiler::Compiler()
     : _cliApp("picceler compiler"), _cliOptions(), _parser(), _context(initRegistry()), _mlirGen(&_context),
       _passManager(&_context) {
-  _cliApp.add_option("input_file", _cliOptions.inputFile, "Input source file")->required()->check(CLI::ExistingFile);
-  _cliApp.add_option("-o,--output", _cliOptions.outputFile, "Output executable file")->default_val("a.out");
+  _cliApp.add_option("input_file", _cliOptions._inputFile, "Input source file")->required()->check(CLI::ExistingFile);
+  _cliApp.add_option("-o,--output", _cliOptions._outputFile, "Output executable file")->default_val("a.out");
 
   _context.loadAllAvailableDialects();
   spdlog::debug("Initialized MLIR Dialects:");
@@ -52,9 +52,8 @@ mlir::DialectRegistry Compiler::initRegistry() {
 }
 
 bool Compiler::run() {
-  auto &cliOptions = getCliOptions();
-  const auto &inputFile = _cliOptions.inputFile;
-  const auto &outputFile = _cliOptions.outputFile;
+  const auto &inputFile = _cliOptions._inputFile;
+  const auto &outputFile = _cliOptions._outputFile;
 
   auto sourceResult = _parser.setSource(inputFile);
   if (!sourceResult) {
@@ -135,10 +134,10 @@ bool Compiler::emitObjectFile(llvm::Module *llvmModule, const std::string &objFi
   llvmModule->setDataLayout(targetMachine->createDataLayout());
   llvmModule->setTargetTriple(llvm::Triple(targetTriple));
 
-  std::error_code EC;
-  llvm::raw_fd_ostream dest(objFilename, EC, llvm::sys::fs::OF_None);
-  if (EC) {
-    spdlog::error("Could not open file: {}", EC.message());
+  std::error_code ec;
+  llvm::raw_fd_ostream dest(objFilename, ec, llvm::sys::fs::OF_None);
+  if (ec) {
+    spdlog::error("Could not open file: {}", ec.message());
     return false;
   }
 
@@ -159,7 +158,7 @@ bool Compiler::linkWithLLD(const std::string &objFile, const std::string &runtim
       "clang++ " + objFile + " " + runtimeLib + " -o " + outputExe + " -no-pie $(pkg-config --libs opencv4)";
   spdlog::debug("Linking with command: {}", cmd);
 
-  int ret = std::system(cmd.c_str());
+  int ret = std::system(cmd.c_str()); // NOLINT(bugprone-command-processor)
   if (ret == 0) {
     spdlog::info("Successfully linked executable: {}", outputExe);
     return true;

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -21,6 +21,10 @@
 #include "llvm/MC/TargetRegistry.h"
 #include "llvm/IR/LegacyPassManager.h"
 #include "llvm/Target/TargetOptions.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Dialect.h"
 
 namespace picceler {
 
@@ -77,15 +81,17 @@ bool Compiler::run() {
     spdlog::error("Failed to reset source file: {}", resetResult.error().message());
     return false;
   }
-  auto ast = _parser.parse();
-  if (!ast) {
-    spdlog::error("{}", ast.error().message());
+  auto astResult = _parser.parse();
+  if (!astResult) {
+    spdlog::error("{}", astResult.error().message());
     return false;
   }
-  _parser.printAST(ast.value());
+  auto ast = std::move(astResult.value());
+  _parser.printAST(ast);
+  ast->normalizeTopLevelStatements();
 
   spdlog::info("Generating initial MLIR");
-  auto module = _mlirGen.generate(ast.value().get());
+  auto module = _mlirGen.generate(ast.get());
   spdlog::info("Finished generating initial MLIR");
   module->dump();
   spdlog::info("Running pass manager");

--- a/src/image_access_helper.cpp
+++ b/src/image_access_helper.cpp
@@ -2,7 +2,7 @@
 
 namespace picceler {
 ImageAccessHelper::ImageAccessHelper(mlir::Value ptr, mlir::OpBuilder &b, mlir::Location l)
-    : structPtr(ptr), builder(b), loc(l) {}
+    : _structPtr(ptr), _builder(b), _loc(l) {}
 
 mlir::Type ImageAccessHelper::getImageStructType(mlir::MLIRContext *ctx) {
   mlir::Type i32 = mlir::IntegerType::get(ctx, 32);
@@ -11,8 +11,8 @@ mlir::Type ImageAccessHelper::getImageStructType(mlir::MLIRContext *ctx) {
 }
 
 mlir::Value ImageAccessHelper::getFieldAddr(int32_t index) {
-  auto structType = getImageStructType(builder.getContext());
-  auto ptrType = mlir::LLVM::LLVMPointerType::get(builder.getContext());
+  auto structType = getImageStructType(_builder.getContext());
+  auto ptrType = mlir::LLVM::LLVMPointerType::get(_builder.getContext());
 
   // We use GEPArg to tell MLIR these are static constant indices.
   // {0, index} means: start at base pointer, go to field 'index'.
@@ -20,25 +20,25 @@ mlir::Value ImageAccessHelper::getFieldAddr(int32_t index) {
   indices.push_back(0);
   indices.push_back(index);
 
-  return builder.create<mlir::LLVM::GEPOp>(loc,
-                                           ptrType,    // Result is a pointer to the field
-                                           structType, // The layout we are indexing into
-                                           structPtr,  // The base opaque pointer
-                                           indices);
+  return _builder.create<mlir::LLVM::GEPOp>(_loc,
+                                            ptrType,    // Result is a pointer to the field
+                                            structType, // The layout we are indexing into
+                                            _structPtr, // The base opaque pointer
+                                            indices);
 }
 
 mlir::Value ImageAccessHelper::getWidth() {
-  mlir::Type i32 = mlir::IntegerType::get(builder.getContext(), 32);
-  return builder.create<mlir::LLVM::LoadOp>(loc, i32, getFieldAddr(0));
+  mlir::Type i32 = mlir::IntegerType::get(_builder.getContext(), 32);
+  return _builder.create<mlir::LLVM::LoadOp>(_loc, i32, getFieldAddr(0));
 }
 
 mlir::Value ImageAccessHelper::getHeight() {
-  mlir::Type i32 = mlir::IntegerType::get(builder.getContext(), 32);
-  return builder.create<mlir::LLVM::LoadOp>(loc, i32, getFieldAddr(1));
+  mlir::Type i32 = mlir::IntegerType::get(_builder.getContext(), 32);
+  return _builder.create<mlir::LLVM::LoadOp>(_loc, i32, getFieldAddr(1));
 }
 
 mlir::Value ImageAccessHelper::getDataPtr() {
-  mlir::Type ptrType = mlir::LLVM::LLVMPointerType::get(builder.getContext());
-  return builder.create<mlir::LLVM::LoadOp>(loc, ptrType, getFieldAddr(2));
+  mlir::Type ptrType = mlir::LLVM::LLVMPointerType::get(_builder.getContext());
+  return _builder.create<mlir::LLVM::LoadOp>(_loc, ptrType, getFieldAddr(2));
 }
 } // namespace picceler

--- a/src/image_access_helper.cpp
+++ b/src/image_access_helper.cpp
@@ -1,4 +1,5 @@
 #include "image_access_helper.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 
 namespace picceler {
 ImageAccessHelper::ImageAccessHelper(mlir::Value ptr, mlir::OpBuilder &b, mlir::Location l)

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -1,6 +1,5 @@
 #include "lexer.h"
 
-#include <iostream>
 #include <format>
 
 #include "spdlog/spdlog.h"

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -71,7 +71,7 @@ Result<Token> Lexer::nextToken() {
   skipWhitespace();
 
   if (eof()) {
-    return Token{Token::Type::EOF_TOKEN, "", _line, _column};
+    return Token{Token::Type::EOF_TOKEN, "", Location{{_line, _column}}};
   }
 
   char ch;
@@ -90,7 +90,7 @@ Result<Token> Lexer::nextToken() {
   }
 
   get(); // consume unknown character
-  return Token{Token::Type::UNKNOWN, "", _line, _column};
+  return Token{Token::Type::UNKNOWN, "", Location{{_line, _column}}};
 }
 
 Result<Token> Lexer::peekToken() {
@@ -145,8 +145,8 @@ char Lexer::get() {
 bool Lexer::isIdentifier(char ch) const { return isalpha(ch) || ch == '_'; }
 
 bool Lexer::isSymbol(char ch) const {
-  static const std::string _symbols = "=():,[]{}->=";
-  return _symbols.find(ch) != std::string::npos;
+  static const std::string symbols = "=():,[]{}->=";
+  return symbols.find(ch) != std::string::npos;
 }
 
 Result<Token::Type> Lexer::isKeyword(const std::string &value) const {
@@ -183,14 +183,14 @@ Result<Token> Lexer::readIdentifierOrKeywordOrType(std::pair<size_t, size_t> sta
   auto result = isKeyword(value);
   if (result) {
     Token::Type keywordType = *result;
-    return Token{keywordType, value, start.first, start.second};
+    return Token{keywordType, value, Location{start}};
   }
   result = isType(value);
   if (result) {
     Token::Type typeType = *result;
-    return Token{typeType, value, start.first, start.second};
+    return Token{typeType, value, Location{start}};
   }
-  return Token{Token::Type::IDENTIFIER, value, start.first, start.second};
+  return Token{Token::Type::IDENTIFIER, value, Location{start}};
 }
 
 Result<Token> Lexer::readNumber(std::pair<size_t, size_t> start) {
@@ -206,8 +206,7 @@ Result<Token> Lexer::readNumber(std::pair<size_t, size_t> start) {
       value += get();
     } else if (ch == '.') {
       if (hasDot) {
-        return std::unexpected(
-            CompileError{"Invalid number format: multiple decimal points", start.first, start.second});
+        return std::unexpected(CompileError{"Invalid number format: multiple decimal points", Location{start}});
       }
       hasDot = true;
       value += get();
@@ -215,7 +214,7 @@ Result<Token> Lexer::readNumber(std::pair<size_t, size_t> start) {
       break;
     }
   }
-  return Token{Token::Type::NUMBER, value, start.first, start.second};
+  return Token{Token::Type::NUMBER, value, Location{start}};
 }
 
 Result<Token> Lexer::readString(std::pair<size_t, size_t> start) {
@@ -227,38 +226,38 @@ Result<Token> Lexer::readString(std::pair<size_t, size_t> start) {
   }
   if (!eof())
     get(); // consume the closing quote
-  return Token{Token::Type::STRING, value, start.first, start.second};
+  return Token{Token::Type::STRING, value, Location{start}};
 }
 
 Result<Token> Lexer::readSymbol(std::pair<size_t, size_t> start) {
   char ch = get();
   switch (ch) {
   case '(':
-    return Token{Token::Type::L_PAREN, "(", start.first, start.second};
+    return Token{Token::Type::L_PAREN, "(", Location{start}};
   case ')':
-    return Token{Token::Type::R_PAREN, ")", start.first, start.second};
+    return Token{Token::Type::R_PAREN, ")", Location{start}};
   case '[':
-    return Token{Token::Type::L_BRACKET, "[", start.first, start.second};
+    return Token{Token::Type::L_BRACKET, "[", Location{start}};
   case ']':
-    return Token{Token::Type::R_BRACKET, "]", start.first, start.second};
+    return Token{Token::Type::R_BRACKET, "]", Location{start}};
   case '{':
-    return Token{Token::Type::L_BRACE, "{", start.first, start.second};
+    return Token{Token::Type::L_BRACE, "{", Location{start}};
   case '}':
-    return Token{Token::Type::R_BRACE, "}", start.first, start.second};
+    return Token{Token::Type::R_BRACE, "}", Location{start}};
   case ',':
-    return Token{Token::Type::COMMA, ",", start.first, start.second};
+    return Token{Token::Type::COMMA, ",", Location{start}};
   case ':':
-    return Token{Token::Type::COLON, ":", start.first, start.second};
+    return Token{Token::Type::COLON, ":", Location{start}};
   case '-':
     if (!eof() && peek() == '>') {
       get(); // consume '>'
-      return Token{Token::Type::ARROW, "->", start.first, start.second};
+      return Token{Token::Type::ARROW, "->", Location{start}};
     }
-    return Token{Token::Type::UNKNOWN, std::string(1, ch), start.first, start.second};
+    return Token{Token::Type::UNKNOWN, std::string(1, ch), Location{start}};
   case '=':
-    return Token{Token::Type::ASSIGN, "=", start.first, start.second};
+    return Token{Token::Type::ASSIGN, "=", Location{start}};
   default:
-    return Token{Token::Type::UNKNOWN, std::string(1, ch), start.first, start.second};
+    return Token{Token::Type::UNKNOWN, std::string(1, ch), Location{start}};
   }
 }
 

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -158,7 +158,7 @@ Result<Token::Type> Lexer::isKeyword(const std::string &value) const {
   if (it != keywords.end()) {
     return it->second;
   }
-  return std::unexpected(CompileError{std::format("Not a keyword: {}", value), _line, _column});
+  return std::unexpected(CompileError{std::format("Not a keyword: {}", value), Location{_line, _column}});
 }
 
 Result<Token::Type> Lexer::isType(const std::string &value) const {
@@ -172,7 +172,7 @@ Result<Token::Type> Lexer::isType(const std::string &value) const {
   if (it != types.end()) {
     return it->second;
   }
-  return std::unexpected(CompileError{std::format("Not a type: {}", value), _line, _column});
+  return std::unexpected(CompileError{std::format("Not a type: {}", value), Location{_line, _column}});
 }
 
 Result<Token> Lexer::readIdentifierOrKeywordOrType(std::pair<size_t, size_t> start) {

--- a/src/mlir_gen.cpp
+++ b/src/mlir_gen.cpp
@@ -75,61 +75,10 @@ MLIRGen::~MLIRGen() noexcept {
   exitScope(); // Exit the global scope
 }
 
-bool MLIRGen::normalizeASTMain(mlir::ModuleOp module, ModuleNode *root) {
-  bool hasMain = false;
-  bool onlyFunctions = true;
-  spdlog::info("Printing all statements in the AST:\n");
-  for (const auto &stmt : root->statements()) {
-    spdlog::info("{}\n", stmt->toString());
-  }
-
-  for (const auto &stmt : root->statements()) {
-    if (auto funcNode = dynamic_cast<FunctionNode *>(stmt)) {
-      if (funcNode->name() == "main") {
-        hasMain = true;
-      }
-    } else {
-      onlyFunctions = false;
-    }
-  }
-
-  if (!hasMain) {
-    if (!onlyFunctions) {
-      spdlog::warn("No 'main' functions found, implicit 'main' will be generated to wrap the top-level statements");
-      auto mainFunc = std::make_unique<FunctionNode>("main");
-      for (auto &stmt : root->mutableStatements()) {
-        if (!dynamic_cast<FunctionNode *>(stmt.get())) {
-          mainFunc->addBodyStatement(std::move(stmt));
-        }
-      }
-      root->mutableStatements().erase(std::remove_if(root->mutableStatements().begin(), root->mutableStatements().end(),
-                                                     [&](const std::unique_ptr<ASTNode> &stmt) {
-                                                       return !dynamic_cast<FunctionNode *>(stmt.get());
-                                                     }),
-                                      root->mutableStatements().end());
-      root->mutableStatements().push_back(std::move(mainFunc));
-    } else {
-      spdlog::error("No 'main' function found and no top-level statements to wrap.");
-      return false;
-    }
-  } else {
-    if (!onlyFunctions) {
-      spdlog::warn("Found 'main' function, but also found top-level statements. Not allowed.");
-      return false;
-    }
-  }
-
-  spdlog::info("AST normalization complete. Final AST:\n");
-  for (const auto &stmt : root->statements()) {
-    spdlog::info("{}\n", stmt->toString());
-  }
-  return true;
-}
-
 void MLIRGen::declareUserFunctions(mlir::ModuleOp module, ModuleNode *root) {
   spdlog::debug("Declaring user-defined functions in the MLIR module");
   _builder.setInsertionPointToStart(module.getBody());
-  for (const auto &stmt : root->statements()) {
+  for (auto stmt : root->statements()) {
     if (auto funcNode = dynamic_cast<FunctionNode *>(stmt)) {
       spdlog::debug("Declaring function: {}", funcNode->name());
       std::vector<mlir::Type> funcArgTypes = getFunctionArgTypes(funcNode);
@@ -165,7 +114,7 @@ std::vector<mlir::Type> MLIRGen::getFunctionArgTypes(FunctionNode *funcNode) {
 
 void MLIRGen::defineUserFunctions(mlir::ModuleOp module, ModuleNode *root) {
   spdlog::debug("Defining user-defined functions in the MLIR module");
-  for (const auto &stmt : root->statements()) {
+  for (auto stmt : root->statements()) {
     if (auto funcNode = dynamic_cast<FunctionNode *>(stmt)) {
       auto funcOp = module.lookupSymbol<mlir::func::FuncOp>(funcNode->name());
       if (!funcOp) {
@@ -186,7 +135,7 @@ void MLIRGen::defineUserFunctions(mlir::ModuleOp module, ModuleNode *root) {
         ++argIndex;
       }
 
-      for (const auto &bodyStmt : funcNode->body()) {
+      for (auto bodyStmt : funcNode->body()) {
         emitStatement(bodyStmt);
       }
 
@@ -209,10 +158,6 @@ mlir::ModuleOp MLIRGen::generate(ModuleNode *root) {
   auto module = mlir::ModuleOp::create(_builder.getUnknownLoc());
   registerBuiltinFunctions();
 
-  bool result = normalizeASTMain(module, root);
-  if (!result) {
-    return nullptr;
-  }
   declareUserFunctions(module, root);
   defineUserFunctions(module, root);
 
@@ -333,7 +278,7 @@ mlir::Value MLIRGen::emitAssignment(AssignmentNode *node) {
 mlir::Value MLIRGen::emitCall(CallNode *node) {
   spdlog::debug("Emitting MLIR for call: {}", node->toString());
   std::vector<mlir::Value> args;
-  for (auto &arg : node->arguments()) {
+  for (auto arg : node->arguments()) {
     args.push_back(emitExpression(arg));
   }
   auto op = emitCallExpression(node, args);

--- a/src/mlir_gen.cpp
+++ b/src/mlir_gen.cpp
@@ -59,7 +59,7 @@ mlir::Value coerceValueToInt64(mlir::OpBuilder &builder, mlir::Location loc, mli
     return builder.create<mlir::arith::ConstantIntOp>(loc, static_cast<int64_t>(numericValue), intBitWidth);
   }
 
-  if (auto isRuntimeFloat = mlir::isa<mlir::FloatType>(value.getType())) {
+  if (mlir::isa<mlir::FloatType>(value.getType())) {
     return builder.create<mlir::arith::FPToSIOp>(loc, builder.getI64Type(), value);
   }
 
@@ -71,7 +71,7 @@ MLIRGen::MLIRGen(mlir::MLIRContext *context)
   enterScope("Global"); // Enter the global scope
 }
 
-MLIRGen::~MLIRGen() {
+MLIRGen::~MLIRGen() noexcept {
   exitScope(); // Exit the global scope
 }
 
@@ -79,13 +79,13 @@ bool MLIRGen::normalizeASTMain(mlir::ModuleOp module, ModuleNode *root) {
   bool hasMain = false;
   bool onlyFunctions = true;
   spdlog::info("Printing all statements in the AST:\n");
-  for (const auto &stmt : root->statements) {
+  for (const auto &stmt : root->statements()) {
     spdlog::info("{}\n", stmt->toString());
   }
 
-  for (const auto &stmt : root->statements) {
-    if (auto funcNode = dynamic_cast<FunctionNode *>(stmt.get())) {
-      if (funcNode->name == "main") {
+  for (const auto &stmt : root->statements()) {
+    if (auto funcNode = dynamic_cast<FunctionNode *>(stmt)) {
+      if (funcNode->name() == "main") {
         hasMain = true;
       }
     } else {
@@ -96,19 +96,18 @@ bool MLIRGen::normalizeASTMain(mlir::ModuleOp module, ModuleNode *root) {
   if (!hasMain) {
     if (!onlyFunctions) {
       spdlog::warn("No 'main' functions found, implicit 'main' will be generated to wrap the top-level statements");
-      auto mainFunc = std::make_unique<FunctionNode>();
-      mainFunc->name = "main";
-      for (auto &stmt : root->statements) {
+      auto mainFunc = std::make_unique<FunctionNode>("main");
+      for (auto &stmt : root->mutableStatements()) {
         if (!dynamic_cast<FunctionNode *>(stmt.get())) {
-          mainFunc->body.push_back(std::move(stmt));
+          mainFunc->addBodyStatement(std::move(stmt));
         }
       }
-      root->statements.erase(std::remove_if(root->statements.begin(), root->statements.end(),
-                                            [&](const std::unique_ptr<ASTNode> &stmt) {
-                                              return !dynamic_cast<FunctionNode *>(stmt.get());
-                                            }),
-                             root->statements.end());
-      root->statements.push_back(std::move(mainFunc));
+      root->mutableStatements().erase(std::remove_if(root->mutableStatements().begin(), root->mutableStatements().end(),
+                                                     [&](const std::unique_ptr<ASTNode> &stmt) {
+                                                       return !dynamic_cast<FunctionNode *>(stmt.get());
+                                                     }),
+                                      root->mutableStatements().end());
+      root->mutableStatements().push_back(std::move(mainFunc));
     } else {
       spdlog::error("No 'main' function found and no top-level statements to wrap.");
       return false;
@@ -121,7 +120,7 @@ bool MLIRGen::normalizeASTMain(mlir::ModuleOp module, ModuleNode *root) {
   }
 
   spdlog::info("AST normalization complete. Final AST:\n");
-  for (const auto &stmt : root->statements) {
+  for (const auto &stmt : root->statements()) {
     spdlog::info("{}\n", stmt->toString());
   }
   return true;
@@ -130,13 +129,13 @@ bool MLIRGen::normalizeASTMain(mlir::ModuleOp module, ModuleNode *root) {
 void MLIRGen::declareUserFunctions(mlir::ModuleOp module, ModuleNode *root) {
   spdlog::debug("Declaring user-defined functions in the MLIR module");
   _builder.setInsertionPointToStart(module.getBody());
-  for (const auto &stmt : root->statements) {
-    if (auto funcNode = dynamic_cast<FunctionNode *>(stmt.get())) {
-      spdlog::debug("Declaring function: {}", funcNode->name);
+  for (const auto &stmt : root->statements()) {
+    if (auto funcNode = dynamic_cast<FunctionNode *>(stmt)) {
+      spdlog::debug("Declaring function: {}", funcNode->name());
       std::vector<mlir::Type> funcArgTypes = getFunctionArgTypes(funcNode);
       auto funcType = _builder.getFunctionType(funcArgTypes, {});
-      auto funcOp = _builder.create<mlir::func::FuncOp>(_builder.getUnknownLoc(), funcNode->name, funcType);
-      _functionTable[funcNode->name] = [&, funcOp](mlir::Location loc, const std::vector<mlir::Value> &args) {
+      auto funcOp = _builder.create<mlir::func::FuncOp>(_builder.getUnknownLoc(), funcNode->name(), funcType);
+      _functionTable[funcNode->name()] = [&, funcOp](mlir::Location loc, const std::vector<mlir::Value> &args) {
         auto callOp = _builder.create<mlir::func::CallOp>(loc, funcOp, args);
         return callOp.getNumResults() > 0 ? callOp.getResult(0) : mlir::Value();
       };
@@ -148,7 +147,7 @@ void MLIRGen::declareUserFunctions(mlir::ModuleOp module, ModuleNode *root) {
 
 std::vector<mlir::Type> MLIRGen::getFunctionArgTypes(FunctionNode *funcNode) {
   std::vector<mlir::Type> argTypes;
-  for (const auto &[paramName, paramType] : funcNode->parameters) {
+  for (const auto &[paramName, paramType] : funcNode->parameters()) {
     if (paramType == "image") {
       argTypes.push_back(_builder.getType<ImageType>());
     } else if (paramType == "string") {
@@ -166,29 +165,29 @@ std::vector<mlir::Type> MLIRGen::getFunctionArgTypes(FunctionNode *funcNode) {
 
 void MLIRGen::defineUserFunctions(mlir::ModuleOp module, ModuleNode *root) {
   spdlog::debug("Defining user-defined functions in the MLIR module");
-  for (const auto &stmt : root->statements) {
-    if (auto funcNode = dynamic_cast<FunctionNode *>(stmt.get())) {
-      auto funcOp = module.lookupSymbol<mlir::func::FuncOp>(funcNode->name);
+  for (const auto &stmt : root->statements()) {
+    if (auto funcNode = dynamic_cast<FunctionNode *>(stmt)) {
+      auto funcOp = module.lookupSymbol<mlir::func::FuncOp>(funcNode->name());
       if (!funcOp) {
-        throw std::runtime_error("Function not declared: " + funcNode->name);
+        throw std::runtime_error("Function not declared: " + funcNode->name());
       }
-      spdlog::debug("Defining function: {}", funcNode->name);
+      spdlog::debug("Defining function: {}", funcNode->name());
 
       mlir::OpBuilder::InsertionGuard guard(_builder);
       _builder.setInsertionPointToStart(funcOp.addEntryBlock());
 
-      enterScope(funcNode->name);
+      enterScope(funcNode->name());
 
       int argIndex = 0;
-      for (const auto &[paramName, paramType] : funcNode->parameters) {
+      for (const auto &[paramName, paramType] : funcNode->parameters()) {
         (void)paramType; // Suppress unused variable warning
         auto argValue = funcOp.getArgument(argIndex);
         declareVariable(paramName, argValue);
         ++argIndex;
       }
 
-      for (const auto &bodyStmt : funcNode->body) {
-        emitStatement(bodyStmt.get());
+      for (const auto &bodyStmt : funcNode->body()) {
+        emitStatement(bodyStmt);
       }
 
       exitScope();
@@ -233,8 +232,8 @@ void MLIRGen::emitStatement(ASTNode *node) {
 mlir::Value MLIRGen::emitKernel(KernelNode *node) {
   spdlog::debug("Emitting MLIR for kernel: {}", node->toString());
 
-  int rows = node->rows.size();
-  int cols = rows > 0 ? node->rows[0].size() : 0;
+  size_t rows = node->rows().size();
+  size_t cols = rows > 0 ? node->rows()[0].size() : 0;
 
   if (rows == 0 || cols == 0) {
     throw std::runtime_error("Empty kernel is not allowed");
@@ -242,7 +241,7 @@ mlir::Value MLIRGen::emitKernel(KernelNode *node) {
 
   std::vector<double> flatValues;
   flatValues.reserve(rows * cols);
-  for (const auto &row : node->rows) {
+  for (const auto &row : node->rows()) {
     flatValues.insert(flatValues.end(), row.begin(), row.end());
   }
 
@@ -251,7 +250,7 @@ mlir::Value MLIRGen::emitKernel(KernelNode *node) {
 
   auto valuesAttr = mlir::DenseElementsAttr::get(tensorType, llvm::ArrayRef<double>(flatValues));
 
-  auto resultType = KernelType::get(_context, rows, cols);
+  auto resultType = KernelType::get(_context, static_cast<int>(rows), static_cast<int>(cols));
 
   auto op = _builder.create<KernelConstOp>(_builder.getUnknownLoc(), resultType, valuesAttr);
 
@@ -301,11 +300,11 @@ void MLIRGen::enterScope(const std::string &name) {
   _scopedVariableTable.emplace_back(name, VariableTable());
 }
 
-void MLIRGen::exitScope() {
+void MLIRGen::exitScope() noexcept {
   if (!_scopedVariableTable.empty()) {
     _scopedVariableTable.pop_back();
   } else {
-    throw std::runtime_error("Attempted to exit scope when no scopes are active");
+    spdlog::warn("Attempted to exit scope, but no scopes are currently active.");
   }
 }
 
@@ -320,8 +319,8 @@ void MLIRGen::exitScope() {
  */
 mlir::Value MLIRGen::emitAssignment(AssignmentNode *node) {
   spdlog::debug("Emitting MLIR for assignment: {}", node->toString());
-  auto rhs = emitExpression(node->rhs.get());
-  auto varName = node->lhs->name;
+  auto rhs = emitExpression(node->rhs());
+  auto varName = node->lhs()->name();
 
   auto var = lookupVariable(varName);
   if (var) {
@@ -334,8 +333,8 @@ mlir::Value MLIRGen::emitAssignment(AssignmentNode *node) {
 mlir::Value MLIRGen::emitCall(CallNode *node) {
   spdlog::debug("Emitting MLIR for call: {}", node->toString());
   std::vector<mlir::Value> args;
-  for (auto &arg : node->arguments) {
-    args.push_back(emitExpression(arg.get()));
+  for (auto &arg : node->arguments()) {
+    args.push_back(emitExpression(arg));
   }
   auto op = emitCallExpression(node, args);
   return op;
@@ -343,27 +342,27 @@ mlir::Value MLIRGen::emitCall(CallNode *node) {
 
 mlir::Value MLIRGen::emitVariable(VariableNode *node) {
   spdlog::debug("Emitting MLIR for variable: {}", node->toString());
-  auto var = lookupVariable(node->name);
+  auto var = lookupVariable(node->name());
   if (var) {
     return var.value();
   } else {
     spdlog::error("lookupVariable failed with error message {}", var.error().message());
-    spdlog::error("Undefined variable: {}", node->name);
+    spdlog::error("Undefined variable: {}", node->name());
   }
-  throw std::runtime_error("Undefined variable: " + node->name);
+  throw std::runtime_error("Undefined variable: " + node->name());
 }
 
 mlir::Value MLIRGen::emitString(StringNode *node) {
   spdlog::debug("Emitting MLIR for string: {}", node->toString());
   auto stringType = _builder.getType<StringType>();
-  auto valueAttr = mlir::StringAttr::get(_context, node->value);
+  auto valueAttr = mlir::StringAttr::get(_context, node->value());
   return _builder.create<StringConstOp>(_builder.getUnknownLoc(), stringType, valueAttr);
 }
 
 mlir::Value MLIRGen::emitNumber(NumberNode *node) {
   spdlog::debug("Emitting MLIR for number: {}", node->toString());
   return _builder.create<mlir::arith::ConstantFloatOp>(_builder.getUnknownLoc(), _builder.getF64Type(),
-                                                       llvm::APFloat(node->value));
+                                                       llvm::APFloat(node->value()));
 }
 
 void MLIRGen::registerBuiltinFunctions() {
@@ -484,10 +483,10 @@ void MLIRGen::registerBuiltinFunctions() {
 }
 
 mlir::Value MLIRGen::emitCallExpression(CallNode *node, const std::vector<mlir::Value> &args) {
-  const auto &name = node->callee;
+  const auto &name = node->callee();
   mlir::Location loc = _builder.getUnknownLoc();
 
-  auto expectedArgCount = node->arguments.size();
+  auto expectedArgCount = node->arguments().size();
   if (args.size() != expectedArgCount) {
     // TODO: replace with Result<T> and proper error handling, more info on mismatch
     throw std::runtime_error("Function call argument count mismatch for function: " + name);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1,6 +1,5 @@
 #include "parser.h"
 
-#include <iostream>
 #include <format>
 #include <stdexcept>
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -37,7 +37,7 @@ Result<std::unique_ptr<ModuleNode>> Parser::parse() {
       break;
     }
     spdlog::info("Parsed statement: {}", statement->toString());
-    module->statements.push_back(std::move(statement));
+    module->addStatement(std::move(statement));
   }
   spdlog::info("Finished parsing process");
   return module;
@@ -49,7 +49,7 @@ Result<std::unique_ptr<ASTNode>> Parser::parseStatement() {
     spdlog::error("{}", tokenResult.error().message());
     return std::unexpected(CompileError{"parseStatement unexpected stop of parsing"});
   }
-  auto token = *tokenResult;
+  const auto &token = *tokenResult;
   if (token == Token::Type::IDENTIFIER) {
     spdlog::debug("Parsing statement starting with identifier '{}'", token.value());
     auto identifierResult = _lexer.nextToken();
@@ -57,13 +57,13 @@ Result<std::unique_ptr<ASTNode>> Parser::parseStatement() {
       spdlog::error("{}", identifierResult.error().message());
       return std::unexpected(CompileError{"Failed to consume identifier token"});
     }
-    auto identifier = *identifierResult;
+    const auto &identifier = *identifierResult;
     auto nextTokenResult = _lexer.peekToken();
     if (!nextTokenResult) {
       spdlog::error("{}", nextTokenResult.error().message());
       return std::unexpected(CompileError{"Failed to peek next token"});
     }
-    auto nextToken = *nextTokenResult;
+    const auto &nextToken = *nextTokenResult;
     if (nextToken == Token::Type::ASSIGN) {
       return parseAssignment(identifier);
     } else if (nextToken == Token::Type::L_PAREN) {
@@ -78,7 +78,8 @@ Result<std::unique_ptr<ASTNode>> Parser::parseStatement() {
       spdlog::error("{}", defTokenResult.error().message());
       return std::unexpected(CompileError{"Failed to consume 'def' token"});
     }
-    return parseFunctionDefinition(*defTokenResult);
+    auto defToken = std::move(*defTokenResult);
+    return parseFunctionDefinition(defToken);
   } else if (token == Token::Type::EOF_TOKEN) {
     return nullptr;
   } else {
@@ -87,8 +88,8 @@ Result<std::unique_ptr<ASTNode>> Parser::parseStatement() {
   }
 }
 
-Result<std::unique_ptr<ASTNode>> Parser::parseFunctionDefinition([[maybe_unused]] Token defToken) {
-  auto nameTokenResult = _lexer.nextToken(); // consume function name
+Result<std::unique_ptr<ASTNode>> Parser::parseFunctionDefinition([[maybe_unused]] const Token &defToken) {
+  const auto &nameTokenResult = _lexer.nextToken(); // consume function name
   if (!nameTokenResult) {
     spdlog::error("{}", nameTokenResult.error().message());
     return std::unexpected(CompileError{"Failed to consume function name token"});
@@ -97,14 +98,14 @@ Result<std::unique_ptr<ASTNode>> Parser::parseFunctionDefinition([[maybe_unused]
     return std::unexpected(
         CompileError{"Expected function name after 'def'", nameTokenResult->line(), nameTokenResult->column()});
   }
-  auto funcNode = std::make_unique<FunctionNode>();
-  funcNode->name = nameTokenResult->value();
-  auto lParenTokenResult = _lexer.nextToken(); // consume '('
+  auto funcName = nameTokenResult->value();
+  auto funcNode = std::make_unique<FunctionNode>(funcName);
+  const auto &lParenTokenResult = _lexer.nextToken(); // consume '('
   if (!lParenTokenResult) {
     spdlog::error("{}", lParenTokenResult.error().message());
     return std::unexpected(CompileError{"Failed to consume '(' token in function definition"});
   }
-  auto lParenToken = *lParenTokenResult;
+  const auto &lParenToken = *lParenTokenResult;
   if (lParenToken.type() != Token::Type::L_PAREN) {
     return std::unexpected(CompileError{"Expected '(' in function definition"});
   }
@@ -119,7 +120,7 @@ Result<std::unique_ptr<ASTNode>> Parser::parseFunctionDefinition([[maybe_unused]
       spdlog::error("{}", paramTokenResult.error().message());
       return std::unexpected(CompileError{"Failed to consume parameter token in function definition"});
     }
-    auto paramToken = *paramTokenResult;
+    const auto &paramToken = *paramTokenResult;
     if (paramToken != Token::Type::IDENTIFIER) {
       return std::unexpected(CompileError{"Expected parameter name", paramToken.line(), paramToken.column()});
     }
@@ -128,7 +129,7 @@ Result<std::unique_ptr<ASTNode>> Parser::parseFunctionDefinition([[maybe_unused]
       spdlog::error("{}", colonTokenResult.error().message());
       return std::unexpected(CompileError{"Failed to consume ':' token in function definition"});
     }
-    auto colonToken = *colonTokenResult;
+    const auto &colonToken = *colonTokenResult;
     if (colonToken != Token::Type::COLON) {
       return std::unexpected(CompileError{
           std::format("Expected ':' after parameter name at {}:{}", colonToken.line(), colonToken.column())});
@@ -138,11 +139,11 @@ Result<std::unique_ptr<ASTNode>> Parser::parseFunctionDefinition([[maybe_unused]
       spdlog::error("{}", typeTokenResult.error().message());
       return std::unexpected(CompileError{"Failed to consume type token in function definition"});
     }
-    auto typeToken = *typeTokenResult;
+    const auto &typeToken = *typeTokenResult;
     if (typeToken != Token::Type::TYPE) {
       return std::unexpected(CompileError{"Expected type after ':'", typeToken.line(), typeToken.column()});
     }
-    funcNode->parameters.push_back({paramToken.value(), typeToken.value()});
+    funcNode->addParameter(paramToken.value(), typeToken.value());
     tokenItter = _lexer.peekToken();
     if (!tokenItter) {
       spdlog::error("{}", tokenItter.error().message());
@@ -166,7 +167,7 @@ Result<std::unique_ptr<ASTNode>> Parser::parseFunctionDefinition([[maybe_unused]
     spdlog::error("{}", rParenTokenResult.error().message());
     return std::unexpected(CompileError{"Failed to consume ')' token in function definition"});
   }
-  auto rParenToken = *rParenTokenResult;
+  const auto &rParenToken = *rParenTokenResult;
   if (rParenToken != Token::Type::R_PAREN) {
     return std::unexpected(CompileError{"Expected ')' after parameters", rParenToken.line(), rParenToken.column()});
   }
@@ -176,7 +177,7 @@ Result<std::unique_ptr<ASTNode>> Parser::parseFunctionDefinition([[maybe_unused]
     spdlog::error("{}", lBraceTokenResult.error().message());
     return std::unexpected(CompileError{"Failed to consume '{' token in function definition"});
   }
-  auto lBraceToken = *lBraceTokenResult;
+  const auto &lBraceToken = *lBraceTokenResult;
   if (lBraceToken != Token::Type::L_BRACE) {
     return std::unexpected(CompileError{
         std::format("Expected '{{' after function signature at {}:{}", lBraceToken.line(), lBraceToken.column())});
@@ -197,7 +198,7 @@ Result<std::unique_ptr<ASTNode>> Parser::parseFunctionDefinition([[maybe_unused]
     if (!stmt) {
       return std::unexpected(CompileError{"Unexpected end of function body"});
     }
-    funcNode->body.push_back(std::move(stmt));
+    funcNode->addBodyStatement(std::move(stmt));
     tokenItter = _lexer.peekToken();
     if (!tokenItter) {
       spdlog::error("{}", tokenItter.error().message());
@@ -210,7 +211,7 @@ Result<std::unique_ptr<ASTNode>> Parser::parseFunctionDefinition([[maybe_unused]
     spdlog::error("{}", rBraceTokenResult.error().message());
     return std::unexpected(CompileError{"Failed to consume '}' token in function definition"});
   }
-  auto rBraceToken = *rBraceTokenResult;
+  const auto &rBraceToken = *rBraceTokenResult;
   if (rBraceToken != Token::Type::R_BRACE) {
     return std::unexpected(CompileError{
         std::format("Expected '}}' after function body at {}:{}", rBraceToken.line(), rBraceToken.column())});
@@ -219,14 +220,14 @@ Result<std::unique_ptr<ASTNode>> Parser::parseFunctionDefinition([[maybe_unused]
   return funcNode;
 }
 
-Result<std::unique_ptr<ASTNode>> Parser::parseAssignment(Token identifier) {
+Result<std::unique_ptr<ASTNode>> Parser::parseAssignment(const Token &identifier) {
   spdlog::debug("Parsing assignment for identifier '{}'", identifier.value());
   auto eqTokenResult = _lexer.nextToken(); // consume '='
   if (!eqTokenResult) {
     spdlog::error("{}", eqTokenResult.error().message());
     return std::unexpected(CompileError{"Failed to consume '=' token in assignment"});
   }
-  auto eqToken = *eqTokenResult;
+  const auto &eqToken = *eqTokenResult;
   if (eqToken != Token::Type::ASSIGN) {
     return std::unexpected(CompileError{"Expected '=' after identifier", eqToken.line(), eqToken.column()});
   }
@@ -235,32 +236,34 @@ Result<std::unique_ptr<ASTNode>> Parser::parseAssignment(Token identifier) {
     spdlog::error("{}", exprResult.error().message());
     return std::unexpected(CompileError{"Failed to parse expression in assignment"});
   }
-  auto assignNode = std::make_unique<AssignmentNode>();
+  auto exprVar = std::move(exprResult.value());
   auto leftVarResult = parseVariable(identifier);
   if (!leftVarResult) {
     spdlog::error("{}", leftVarResult.error().message());
     return std::unexpected(CompileError{"Failed to parse variable in assignment"});
   }
   auto leftVar = std::move(leftVarResult.value());
-  assignNode->lhs = std::unique_ptr<VariableNode>(dynamic_cast<VariableNode *>(leftVar.release()));
-  assignNode->rhs = std::move(exprResult.value());
+  if (dynamic_cast<VariableNode *>(leftVar.get()) == nullptr) {
+    return std::unexpected(CompileError{"Left-hand side of assignment must be a variable"});
+  }
+  auto leftVarNode = std::unique_ptr<VariableNode>(static_cast<VariableNode *>(leftVar.release()));
+  auto assignNode = std::make_unique<AssignmentNode>(std::move(leftVarNode), std::move(exprVar));
   return assignNode;
 }
 
-Result<std::unique_ptr<ASTNode>> Parser::parseCall(Token identifier) {
+Result<std::unique_ptr<ASTNode>> Parser::parseCall(const Token &identifier) {
   spdlog::debug("Parsing function call for identifier '{}'", identifier.value());
   auto lparenTokenResult = _lexer.nextToken(); // consume '('
   if (!lparenTokenResult) {
     spdlog::error("{}", lparenTokenResult.error().message());
     return std::unexpected(CompileError{"Failed to consume '(' token in function call"});
   }
-  auto lparenToken = *lparenTokenResult;
+  const auto &lparenToken = *lparenTokenResult;
   if (lparenToken != Token::Type::L_PAREN) {
     return std::unexpected(CompileError{
         std::format("Expected '(' after function name at {}:{}", lparenToken.line(), lparenToken.column())});
   }
-  auto callNode = std::make_unique<CallNode>();
-  callNode->callee = identifier.value();
+  auto callNode = std::make_unique<CallNode>(identifier.value());
 
   while (true) {
     auto nextTokenResult = _lexer.peekToken();
@@ -268,7 +271,7 @@ Result<std::unique_ptr<ASTNode>> Parser::parseCall(Token identifier) {
       spdlog::error("{}", nextTokenResult.error().message());
       return std::unexpected(CompileError{"Failed to peek next token in function call"});
     }
-    auto nextToken = *nextTokenResult;
+    auto &nextToken = *nextTokenResult;
     if (nextToken == Token::Type::R_PAREN) {
       auto rparenTokenResult = _lexer.nextToken(); // consume ')'
       if (!rparenTokenResult) {
@@ -283,7 +286,7 @@ Result<std::unique_ptr<ASTNode>> Parser::parseCall(Token identifier) {
       return std::unexpected(CompileError{"Failed to parse argument in function call"});
     }
     auto arg = std::move(argResult.value());
-    callNode->arguments.push_back(std::move(arg));
+    callNode->addArgument(std::move(arg));
 
     nextTokenResult = _lexer.peekToken();
     if (!nextTokenResult) {
@@ -315,20 +318,20 @@ Result<std::unique_ptr<ASTNode>> Parser::parseExpression() {
     spdlog::error("{}", tokenResult.error().message());
     return std::unexpected(CompileError{"parseExpression unexpected stop of parsing"});
   }
-  auto token = *tokenResult;
+  const auto &token = *tokenResult;
   if (token == Token::Type::IDENTIFIER) {
     auto currentTokenResult = _lexer.nextToken();
     if (!currentTokenResult) {
       spdlog::error("{}", currentTokenResult.error().message());
       return std::unexpected(CompileError{"Failed to consume identifier token in expression"});
     }
-    auto currentToken = *currentTokenResult;
+    const auto &currentToken = *currentTokenResult;
     auto nextTokenResult = _lexer.peekToken();
     if (!nextTokenResult) {
       spdlog::error("{}", nextTokenResult.error().message());
       return std::unexpected(CompileError{"Failed to peek next token in expression"});
     }
-    auto nextToken = *nextTokenResult;
+    const auto &nextToken = *nextTokenResult;
     if (nextToken == Token::Type::L_PAREN) {
       return parseCall(currentToken);
     } else {
@@ -346,8 +349,9 @@ Result<std::unique_ptr<ASTNode>> Parser::parseExpression() {
   }
 }
 
-Result<std::unique_ptr<ASTNode>> Parser::parseVariable(Token identifier) {
+Result<std::unique_ptr<ASTNode>> Parser::parseVariable(const Token &identifier) {
   spdlog::debug("Parsing variable");
+  std::string varName = identifier.value();
   // If the passed token is not an identifier, consume the next token
   if (identifier != Token::Type::IDENTIFIER) {
     auto identifierResult = _lexer.nextToken();
@@ -355,11 +359,10 @@ Result<std::unique_ptr<ASTNode>> Parser::parseVariable(Token identifier) {
       spdlog::error("{}", identifierResult.error().message());
       return std::unexpected(CompileError{"Failed to consume identifier token in variable"});
     }
-    identifier = *identifierResult;
+    varName = identifierResult->value();
   }
 
-  auto varNode = std::make_unique<VariableNode>();
-  varNode->name = identifier.value();
+  auto varNode = std::make_unique<VariableNode>(varName, std::nullopt);
   return varNode;
 }
 
@@ -370,7 +373,7 @@ Result<std::unique_ptr<ASTNode>> Parser::parseKernel() {
     spdlog::error("{}", lbracketTokenResult.error().message());
     return std::unexpected(CompileError{"Failed to consume '[' token in kernel"});
   }
-  auto lbracketToken = *lbracketTokenResult;
+  const auto &lbracketToken = *lbracketTokenResult;
   if (lbracketToken != Token::Type::L_BRACKET) {
     return std::unexpected(CompileError{"Expected '['", lbracketToken.line(), lbracketToken.column()});
   }
@@ -383,7 +386,7 @@ Result<std::unique_ptr<ASTNode>> Parser::parseKernel() {
       spdlog::error("{}", peekedtokenResult.error().message());
       return std::unexpected(CompileError{"Failed to peek token in kernel"});
     }
-    auto peekToken = *peekedtokenResult;
+    const auto &peekToken = *peekedtokenResult;
 
     // End of kernel
     if (peekToken == Token::Type::R_BRACKET) {
@@ -416,7 +419,7 @@ Result<std::unique_ptr<ASTNode>> Parser::parseKernel() {
         spdlog::error("{}", innerTokenResult.error().message());
         return std::unexpected(CompileError{"Failed to peek token in kernel"});
       }
-      auto innerToken = *innerTokenResult;
+      const auto &innerToken = *innerTokenResult;
 
       if (innerToken == Token::Type::R_BRACKET) {
         // empty row allowed? treat as end of row
@@ -438,7 +441,7 @@ Result<std::unique_ptr<ASTNode>> Parser::parseKernel() {
         spdlog::error("{}", numTokenResult.error().message());
         return std::unexpected(CompileError{"Failed to consume number token in kernel"});
       }
-      auto numToken = *numTokenResult;
+      const auto &numToken = *numTokenResult;
       row.push_back(std::stod(numToken.value()));
 
       // after a number, expect ',' or ']'
@@ -447,7 +450,7 @@ Result<std::unique_ptr<ASTNode>> Parser::parseKernel() {
         spdlog::error("{}", afterNumResult.error().message());
         return std::unexpected(CompileError{"Failed to peek token in kernel"});
       }
-      auto afterNum = *afterNumResult;
+      const auto &afterNum = *afterNumResult;
       if (afterNum == Token::Type::COMMA) {
         auto commaTokenResult = _lexer.nextToken(); // consume comma
         if (!commaTokenResult) {
@@ -469,7 +472,7 @@ Result<std::unique_ptr<ASTNode>> Parser::parseKernel() {
     }
 
     // push parsed row
-    kernelNode->rows.push_back(row);
+    kernelNode->addRow(row);
 
     // after a row, look for either ',' (another row) or ']' (end of kernel)
     auto nextResult = _lexer.peekToken();
@@ -477,7 +480,7 @@ Result<std::unique_ptr<ASTNode>> Parser::parseKernel() {
       spdlog::error("{}", nextResult.error().message());
       return std::unexpected(CompileError{"Failed to peek token in kernel"});
     }
-    auto next = *nextResult;
+    const auto &next = *nextResult;
     if (next == Token::Type::COMMA) {
       auto commaTokenResult = _lexer.nextToken(); // consume comma between rows
       if (!commaTokenResult) {
@@ -499,9 +502,9 @@ Result<std::unique_ptr<ASTNode>> Parser::parseKernel() {
   }
 
   // Validate dimensions: only 2D kernels supported; ensure all rows same length
-  if (!kernelNode->rows.empty()) {
-    size_t cols = kernelNode->rows[0].size();
-    for (const auto &row : kernelNode->rows) {
+  if (!kernelNode->rows().empty()) {
+    size_t cols = kernelNode->rows()[0].size();
+    for (const auto &row : kernelNode->rows()) {
       if (row.size() != cols) {
         return std::unexpected(CompileError{"All rows in kernel must have same length"});
       }
@@ -518,13 +521,12 @@ Result<std::unique_ptr<ASTNode>> Parser::parseString() {
     spdlog::error("{}", tokenResult.error().message());
     return std::unexpected(CompileError{"Failed to consume string token"});
   }
-  auto token = *tokenResult;
+  const auto &token = *tokenResult;
   if (token != Token::Type::STRING) {
     return std::unexpected(CompileError{"Expected string", token.line(), token.column()});
   }
-  auto strNode = std::make_unique<StringNode>();
   // TODO: Implement a compiler flag to let the user not expand tilde if it is not needed
-  strNode->value = utils::expandTilde(token.value());
+  auto strNode = std::make_unique<StringNode>(utils::expandTilde(token.value()));
   return strNode;
 }
 
@@ -535,13 +537,13 @@ Result<std::unique_ptr<ASTNode>> Parser::parseNumber() {
     spdlog::error("{}", tokenResult.error().message());
     return std::unexpected(CompileError{"Failed to consume number token"});
   }
-  auto token = *tokenResult;
+  const auto &token = *tokenResult;
   if (token != Token::Type::NUMBER) {
     return std::unexpected(CompileError{"Expected number", token.line(), token.column()});
   }
-  auto numNode = std::make_unique<NumberNode>();
+  std::unique_ptr<NumberNode> numNode = nullptr;
   try {
-    numNode->value = std::stod(token.value());
+    numNode = std::make_unique<NumberNode>(std::stod(token.value()));
   } catch (const std::invalid_argument &) {
     return std::unexpected(
         CompileError{std::format("Invalid double literal '{}'", token.value()), token.line(), token.column()});
@@ -555,9 +557,8 @@ Result<std::unique_ptr<ASTNode>> Parser::parseNumber() {
 void Parser::printAST(const std::unique_ptr<ModuleNode> &node, int indent) {
   if (!node)
     return;
-  std::string indentStr(indent, ' ');
   spdlog::info("{}", node->toString());
-  for (const auto &stmt : node->statements) {
+  for (const auto &stmt : node->statements()) {
     spdlog::info("{}", stmt->toString());
   }
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -264,7 +264,7 @@ Result<std::unique_ptr<ASTNode>> Parser::parseCall(const Token &identifier) {
       spdlog::error("{}", nextTokenResult.error().message());
       return std::unexpected(CompileError{"Failed to peek next token in function call"});
     }
-    auto &nextToken = *nextTokenResult;
+    auto nextToken = *nextTokenResult;
     if (nextToken == Token::Type::R_PAREN) {
       auto rparenTokenResult = _lexer.nextToken(); // consume ')'
       if (!rparenTokenResult) {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -69,8 +69,8 @@ Result<std::unique_ptr<ASTNode>> Parser::parseStatement() {
     } else if (nextToken == Token::Type::L_PAREN) {
       return parseCall(identifier);
     }
-    return std::unexpected(CompileError{std::format("Unexpected token '{}' after identifier", nextToken.value()),
-                                        nextToken.line(), nextToken.column()});
+    return std::unexpected(
+        CompileError{std::format("Unexpected token '{}' after identifier", nextToken.value()), nextToken.location()});
 
   } else if (token == Token::Type::KW_DEF) {
     auto defTokenResult = _lexer.nextToken(); // consume 'def'
@@ -83,8 +83,7 @@ Result<std::unique_ptr<ASTNode>> Parser::parseStatement() {
   } else if (token == Token::Type::EOF_TOKEN) {
     return nullptr;
   } else {
-    return std::unexpected(
-        CompileError{std::format("Unexpected token '{}'", token.value()), token.line(), token.column()});
+    return std::unexpected(CompileError{std::format("Unexpected token '{}'", token.value()), token.location()});
   }
 }
 
@@ -95,8 +94,7 @@ Result<std::unique_ptr<ASTNode>> Parser::parseFunctionDefinition([[maybe_unused]
     return std::unexpected(CompileError{"Failed to consume function name token"});
   }
   if (nameTokenResult->type() != Token::Type::IDENTIFIER) {
-    return std::unexpected(
-        CompileError{"Expected function name after 'def'", nameTokenResult->line(), nameTokenResult->column()});
+    return std::unexpected(CompileError{"Expected function name after 'def'", nameTokenResult->location()});
   }
   auto funcName = nameTokenResult->value();
   auto funcNode = std::make_unique<FunctionNode>(funcName);
@@ -122,7 +120,7 @@ Result<std::unique_ptr<ASTNode>> Parser::parseFunctionDefinition([[maybe_unused]
     }
     const auto &paramToken = *paramTokenResult;
     if (paramToken != Token::Type::IDENTIFIER) {
-      return std::unexpected(CompileError{"Expected parameter name", paramToken.line(), paramToken.column()});
+      return std::unexpected(CompileError{"Expected parameter name", paramToken.location()});
     }
     auto colonTokenResult = _lexer.nextToken(); // consume ':'
     if (!colonTokenResult) {
@@ -131,8 +129,7 @@ Result<std::unique_ptr<ASTNode>> Parser::parseFunctionDefinition([[maybe_unused]
     }
     const auto &colonToken = *colonTokenResult;
     if (colonToken != Token::Type::COLON) {
-      return std::unexpected(CompileError{
-          std::format("Expected ':' after parameter name at {}:{}", colonToken.line(), colonToken.column())});
+      return std::unexpected(CompileError{std::format("Expected ':' after parameter name"), colonToken.location()});
     }
     auto typeTokenResult = _lexer.nextToken(); // consume type
     if (!typeTokenResult) {
@@ -141,7 +138,7 @@ Result<std::unique_ptr<ASTNode>> Parser::parseFunctionDefinition([[maybe_unused]
     }
     const auto &typeToken = *typeTokenResult;
     if (typeToken != Token::Type::TYPE) {
-      return std::unexpected(CompileError{"Expected type after ':'", typeToken.line(), typeToken.column()});
+      return std::unexpected(CompileError{"Expected type after ':'", typeToken.location()});
     }
     funcNode->addParameter(paramToken.value(), typeToken.value());
     tokenItter = _lexer.peekToken();
@@ -169,7 +166,7 @@ Result<std::unique_ptr<ASTNode>> Parser::parseFunctionDefinition([[maybe_unused]
   }
   const auto &rParenToken = *rParenTokenResult;
   if (rParenToken != Token::Type::R_PAREN) {
-    return std::unexpected(CompileError{"Expected ')' after parameters", rParenToken.line(), rParenToken.column()});
+    return std::unexpected(CompileError{"Expected ')' after parameters", rParenToken.location()});
   }
 
   auto lBraceTokenResult = _lexer.nextToken(); // consume '{'
@@ -179,8 +176,7 @@ Result<std::unique_ptr<ASTNode>> Parser::parseFunctionDefinition([[maybe_unused]
   }
   const auto &lBraceToken = *lBraceTokenResult;
   if (lBraceToken != Token::Type::L_BRACE) {
-    return std::unexpected(CompileError{
-        std::format("Expected '{{' after function signature at {}:{}", lBraceToken.line(), lBraceToken.column())});
+    return std::unexpected(CompileError{std::format("Expected '{{' after function signature"), lBraceToken.location()});
   }
 
   tokenItter = _lexer.peekToken();
@@ -213,8 +209,7 @@ Result<std::unique_ptr<ASTNode>> Parser::parseFunctionDefinition([[maybe_unused]
   }
   const auto &rBraceToken = *rBraceTokenResult;
   if (rBraceToken != Token::Type::R_BRACE) {
-    return std::unexpected(CompileError{
-        std::format("Expected '}}' after function body at {}:{}", rBraceToken.line(), rBraceToken.column())});
+    return std::unexpected(CompileError{std::format("Expected '}}' after function body"), rBraceToken.location()});
   }
 
   return funcNode;
@@ -229,7 +224,7 @@ Result<std::unique_ptr<ASTNode>> Parser::parseAssignment(const Token &identifier
   }
   const auto &eqToken = *eqTokenResult;
   if (eqToken != Token::Type::ASSIGN) {
-    return std::unexpected(CompileError{"Expected '=' after identifier", eqToken.line(), eqToken.column()});
+    return std::unexpected(CompileError{"Expected '=' after identifier", eqToken.location()});
   }
   auto exprResult = parseExpression();
   if (!exprResult) {
@@ -260,8 +255,7 @@ Result<std::unique_ptr<ASTNode>> Parser::parseCall(const Token &identifier) {
   }
   const auto &lparenToken = *lparenTokenResult;
   if (lparenToken != Token::Type::L_PAREN) {
-    return std::unexpected(CompileError{
-        std::format("Expected '(' after function name at {}:{}", lparenToken.line(), lparenToken.column())});
+    return std::unexpected(CompileError{std::format("Expected '(' after function name"), lparenToken.location()});
   }
   auto callNode = std::make_unique<CallNode>(identifier.value());
 
@@ -303,8 +297,7 @@ Result<std::unique_ptr<ASTNode>> Parser::parseCall(const Token &identifier) {
     } else if (nextToken == Token::Type::R_PAREN) {
       continue;
     } else {
-      return std::unexpected(CompileError{
-          std::format("Expected ',' or ')' in function call at {}:{}", nextToken.line(), nextToken.column())});
+      return std::unexpected(CompileError{std::format("Expected ',' or ')' in function call "), nextToken.location()});
     }
   }
 
@@ -344,8 +337,7 @@ Result<std::unique_ptr<ASTNode>> Parser::parseExpression() {
   } else if (token == Token::Type::L_BRACKET) {
     return parseKernel();
   } else {
-    return std::unexpected(
-        CompileError{std::format("Unexpected token '{}'", token.value()), token.line(), token.column()});
+    return std::unexpected(CompileError{std::format("Unexpected token '{}'", token.value()), token.location()});
   }
 }
 
@@ -375,7 +367,7 @@ Result<std::unique_ptr<ASTNode>> Parser::parseKernel() {
   }
   const auto &lbracketToken = *lbracketTokenResult;
   if (lbracketToken != Token::Type::L_BRACKET) {
-    return std::unexpected(CompileError{"Expected '['", lbracketToken.line(), lbracketToken.column()});
+    return std::unexpected(CompileError{"Expected '['", lbracketToken.location()});
   }
 
   auto kernelNode = std::make_unique<KernelNode>();
@@ -401,7 +393,7 @@ Result<std::unique_ptr<ASTNode>> Parser::parseKernel() {
     // Expect a row: '[' NUMBER (',' NUMBER)* ']'
 
     if (!(peekToken == Token::Type::L_BRACKET)) {
-      return std::unexpected(CompileError{"Expected '[' for kernel row", peekToken.line(), peekToken.column()});
+      return std::unexpected(CompileError{"Expected '[' for kernel row", peekToken.location()});
     }
 
     // consume inner '['
@@ -433,7 +425,7 @@ Result<std::unique_ptr<ASTNode>> Parser::parseKernel() {
 
       // expect a number
       if (innerToken != Token::Type::NUMBER) {
-        return std::unexpected(CompileError{"Expected number in kernel", innerToken.line(), innerToken.column()});
+        return std::unexpected(CompileError{"Expected number in kernel", innerToken.location()});
       }
       // consume number
       auto numTokenResult = _lexer.nextToken();
@@ -467,7 +459,7 @@ Result<std::unique_ptr<ASTNode>> Parser::parseKernel() {
         }
         break;
       } else {
-        return std::unexpected(CompileError{"Expected ',' or ']' in kernel row", afterNum.line(), afterNum.column()});
+        return std::unexpected(CompileError{"Expected ',' or ']' in kernel row", afterNum.location()});
       }
     }
 
@@ -497,7 +489,7 @@ Result<std::unique_ptr<ASTNode>> Parser::parseKernel() {
       }
       break;
     } else {
-      return std::unexpected(CompileError{"Expected ',' or ']' after kernel row", next.line(), next.column()});
+      return std::unexpected(CompileError{"Expected ',' or ']' after kernel row", next.location()});
     }
   }
 
@@ -523,7 +515,7 @@ Result<std::unique_ptr<ASTNode>> Parser::parseString() {
   }
   const auto &token = *tokenResult;
   if (token != Token::Type::STRING) {
-    return std::unexpected(CompileError{"Expected string", token.line(), token.column()});
+    return std::unexpected(CompileError{"Expected string", token.location()});
   }
   // TODO: Implement a compiler flag to let the user not expand tilde if it is not needed
   auto strNode = std::make_unique<StringNode>(utils::expandTilde(token.value()));
@@ -539,17 +531,16 @@ Result<std::unique_ptr<ASTNode>> Parser::parseNumber() {
   }
   const auto &token = *tokenResult;
   if (token != Token::Type::NUMBER) {
-    return std::unexpected(CompileError{"Expected number", token.line(), token.column()});
+    return std::unexpected(CompileError{"Expected number", token.location()});
   }
   std::unique_ptr<NumberNode> numNode = nullptr;
   try {
     numNode = std::make_unique<NumberNode>(std::stod(token.value()));
   } catch (const std::invalid_argument &) {
-    return std::unexpected(
-        CompileError{std::format("Invalid double literal '{}'", token.value()), token.line(), token.column()});
+    return std::unexpected(CompileError{std::format("Invalid double literal '{}'", token.value()), token.location()});
   } catch (const std::out_of_range &) {
     return std::unexpected(
-        CompileError{std::format("Double literal '{}' out of range", token.value()), token.line(), token.column()});
+        CompileError{std::format("Double literal '{}' out of range", token.value()), token.location()});
   }
   return numNode;
 }

--- a/src/pass_manager.cpp
+++ b/src/pass_manager.cpp
@@ -7,8 +7,10 @@
  * and performance analysis.
  */
 
+#include "passes.h"
 #include "pass_manager.h"
 
+#include "llvm/Support/FileSystem.h"
 #include "mlir/Transforms/Passes.h"
 #include "mlir/Conversion/ReconcileUnrealizedCasts/ReconcileUnrealizedCasts.h"
 #include "mlir/Conversion/AffineToStandard/AffineToStandard.h"

--- a/src/picceler_filters_to_conv_pass.cpp
+++ b/src/picceler_filters_to_conv_pass.cpp
@@ -1,6 +1,5 @@
 #include "passes.h"
 
-#include "spdlog/spdlog.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/IR/Builders.h"
@@ -14,10 +13,19 @@
 
 namespace picceler {
 
-struct KernelData {
-  int64_t rows;
-  int64_t cols;
-  std::vector<double> values;
+class KernelData {
+public:
+  KernelData(int64_t rows, int64_t cols, std::vector<double> values)
+      : _rows(rows), _cols(cols), _values(std::move(values)) {}
+
+  int64_t rows() const { return _rows; }
+  int64_t cols() const { return _cols; }
+  const std::vector<double> &values() const { return _values; }
+
+private:
+  int64_t _rows;
+  int64_t _cols;
+  std::vector<double> _values;
 };
 
 mlir::FailureOr<KernelData> calculateSharpenKernel(SharpenOp op, SharpenOpAdaptor adaptor) {
@@ -43,7 +51,7 @@ mlir::FailureOr<KernelData> calculateBoxBlurKernel(BoxBlurOp op, BoxBlurOpAdapto
     op.emitError("Box blur supports only constant integer radius values.");
     return mlir::failure();
   }
-  int radius = constOp.value();
+  int64_t radius = constOp.value();
 
   if (radius < 1) {
     op.emitError("Box blur radius must be at least 1. Given: " + std::to_string(radius));
@@ -70,7 +78,7 @@ mlir::FailureOr<KernelData> calculateGaussianKernel(GaussianBlurOp op, GaussianB
     op.emitError("Gaussian blur supports only constant integer radius values.");
     return mlir::failure();
   }
-  int radius = constOp.value();
+  int64_t radius = constOp.value();
 
   if (radius < 1) {
     op.emitError("Gaussian blur radius must be at least 1. Given: " + std::to_string(radius));
@@ -92,9 +100,9 @@ mlir::FailureOr<KernelData> calculateGaussianKernel(GaussianBlurOp op, GaussianB
 
   double sum = 0.0;
 
-  for (int y = -radius; y <= radius; ++y) {
-    for (int x = -radius; x <= radius; ++x) {
-      double exponent = -(x * x + y * y) / (2 * sigma * sigma);
+  for (int64_t y = -radius; y <= radius; ++y) {
+    for (int64_t x = -radius; x <= radius; ++x) {
+      double exponent = static_cast<double>(-(x * x + y * y)) / (2 * sigma * sigma);
       double value = std::exp(exponent) / (2 * std::numbers::pi * sigma * sigma);
       values.push_back(value);
       sum += value;
@@ -119,10 +127,8 @@ mlir::FailureOr<KernelData> calculateEmbossKernel(EmbossOp op, EmbossOpAdaptor a
 template <typename OpTy> struct FilterToConvolutionPattern : mlir::OpConversionPattern<OpTy> {
   using KernelCalculator = std::function<mlir::FailureOr<KernelData>(OpTy, typename OpTy::Adaptor)>;
 
-  KernelCalculator kernelCalc;
-
   FilterToConvolutionPattern(mlir::MLIRContext *ctx, KernelCalculator calc)
-      : mlir::OpConversionPattern<OpTy>(ctx), kernelCalc(calc) {}
+      : mlir::OpConversionPattern<OpTy>(ctx), _kernelCalc(std::move(calc)) {}
 
   mlir::LogicalResult matchAndRewrite(OpTy op, OpTy::Adaptor adaptor,
                                       mlir::ConversionPatternRewriter &rewriter) const override {
@@ -130,27 +136,32 @@ template <typename OpTy> struct FilterToConvolutionPattern : mlir::OpConversionP
     mlir::Value input = adaptor.getInput();
     auto f64Type = rewriter.getF64Type();
 
-    auto kernelRes = kernelCalc(op, adaptor);
+    auto kernelRes = _kernelCalc(op, adaptor);
     if (mlir::failed(kernelRes)) {
       return mlir::failure();
     }
 
-    KernelData kData = *kernelRes;
-    if (kData.values.size() != kData.rows * kData.cols) {
+    // TODO: remove NOLINT comment once we return Result<T>, clang-tidy should be able to understand that we checked for
+    // failure above.
+    const KernelData &kData = *kernelRes; // NOLINT(bugprone-unchecked-optional-access)
+    if (kData.values().size() != kData.rows() * kData.cols()) {
       op.emitError("Kernel dimensions do not match the number of elements.");
       return mlir::failure();
     }
 
-    auto tensorType = mlir::RankedTensorType::get({kData.rows, kData.cols}, f64Type);
-    auto dataAttr = mlir::DenseElementsAttr::get(tensorType, llvm::ArrayRef(kData.values));
+    auto tensorType = mlir::RankedTensorType::get({kData.rows(), kData.cols()}, f64Type);
+    auto dataAttr = mlir::DenseElementsAttr::get(tensorType, llvm::ArrayRef(kData.values()));
 
-    auto kernelType = picceler::KernelType::get(op.getContext(), kData.rows, kData.cols);
+    auto kernelType = picceler::KernelType::get(op.getContext(), kData.rows(), kData.cols());
     auto kernelOp = rewriter.create<picceler::KernelConstOp>(loc, kernelType, dataAttr);
 
     rewriter.replaceOpWithNewOp<ConvolutionOp>(op, op.getType(), input, kernelOp.getResult());
 
     return mlir::success();
   }
+
+private:
+  KernelCalculator _kernelCalc;
 };
 
 #define GEN_PASS_DEF_PICCELERFILTERSTOCONV

--- a/src/picceler_kernel_to_memref_pass.cpp
+++ b/src/picceler_kernel_to_memref_pass.cpp
@@ -1,15 +1,12 @@
 #include "passes.h"
 
-#include "spdlog/spdlog.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
-#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/Pass/Pass.h"
-#include "mlir/IR/BuiltinOps.h"
 
 #include "ops.h"
 #include "types.h"

--- a/src/picceler_ops_to_func_calls_pass.cpp
+++ b/src/picceler_ops_to_func_calls_pass.cpp
@@ -1,11 +1,8 @@
 #include "passes.h"
 
-#include "spdlog/spdlog.h"
 #include "mlir/IR/PatternMatch.h"
-#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Transforms/DialectConversion.h"
-#include "mlir/IR/SymbolTable.h"
 
 #include "ops.h"
 #include "types.h"

--- a/src/picceler_ops_to_func_calls_pass.cpp
+++ b/src/picceler_ops_to_func_calls_pass.cpp
@@ -129,9 +129,9 @@ struct ReadNumberToCall : public mlir::OpConversionPattern<ReadNumberOp> {
     auto loc = op.getLoc();
 
     auto stringType = StringType::get(ctx);
-    auto F64Type = rewriter.getF64Type();
+    auto f64Type = rewriter.getF64Type();
 
-    auto func = ensureRuntimeFunc(module, "piccelerReadNumber", {stringType}, {F64Type}, rewriter, loc);
+    auto func = ensureRuntimeFunc(module, "piccelerReadNumber", {stringType}, {f64Type}, rewriter, loc);
     llvm::SmallVector<mlir::Value, 2> args;
     args.push_back(adaptor.getPrompt());
 

--- a/src/picceler_to_affine_pass.cpp
+++ b/src/picceler_to_affine_pass.cpp
@@ -100,7 +100,7 @@ struct BrightnessToAffine : mlir::OpConversionPattern<BrightnessOp> {
 
       auto outputBytePtr =
           rewriter.create<mlir::LLVM::GEPOp>(loc, ptrType, rewriter.getI8Type(), outputDataPtr, byteAddrI64);
-      auto outputByte = rewriter.create<mlir::LLVM::StoreOp>(loc, finalValue, outputBytePtr);
+      rewriter.create<mlir::LLVM::StoreOp>(loc, finalValue, outputBytePtr);
     };
 
     processChannel(Channel::R);
@@ -185,7 +185,7 @@ struct InvertToAffine : mlir::OpConversionPattern<InvertOp> {
 
       auto outputBytePtr =
           rewriter.create<mlir::LLVM::GEPOp>(loc, ptrType, rewriter.getI8Type(), outputDataPtr, byteAddrI64);
-      auto outputByte = rewriter.create<mlir::LLVM::StoreOp>(loc, finalValue, outputBytePtr);
+      rewriter.create<mlir::LLVM::StoreOp>(loc, finalValue, outputBytePtr);
     };
 
     processChannel(Channel::R);
@@ -661,12 +661,12 @@ struct CropToAffine : mlir::OpConversionPattern<CropOp> {
 
     mlir::Value xI32 = adaptor.getX();
     mlir::Value yI32 = adaptor.getY();
-    mlir::Value cropW_I32 = rewriter.create<mlir::arith::TruncIOp>(loc, rewriter.getI32Type(), adaptor.getWidth());
-    mlir::Value cropH_I32 = rewriter.create<mlir::arith::TruncIOp>(loc, rewriter.getI32Type(), adaptor.getHeight());
+    mlir::Value cropWI32 = rewriter.create<mlir::arith::TruncIOp>(loc, rewriter.getI32Type(), adaptor.getWidth());
+    mlir::Value cropHI32 = rewriter.create<mlir::arith::TruncIOp>(loc, rewriter.getI32Type(), adaptor.getHeight());
 
     // create output image with crop size
-    auto createCall = rewriter.create<mlir::func::CallOp>(loc, ptrType, "piccelerCreateImage",
-                                                          mlir::ValueRange{cropW_I32, cropH_I32});
+    auto createCall =
+        rewriter.create<mlir::func::CallOp>(loc, ptrType, "piccelerCreateImage", mlir::ValueRange{cropWI32, cropHI32});
     mlir::Value output = createCall.getResult(0);
 
     ImageAccessHelper outputImage(output, rewriter, loc);
@@ -679,8 +679,8 @@ struct CropToAffine : mlir::OpConversionPattern<CropOp> {
 
     mlir::Value xIndex = rewriter.create<mlir::arith::IndexCastOp>(loc, indexType, xI32);
     mlir::Value yIndex = rewriter.create<mlir::arith::IndexCastOp>(loc, indexType, yI32);
-    mlir::Value cropW = rewriter.create<mlir::arith::IndexCastOp>(loc, indexType, cropW_I32);
-    mlir::Value cropH = rewriter.create<mlir::arith::IndexCastOp>(loc, indexType, cropH_I32);
+    mlir::Value cropW = rewriter.create<mlir::arith::IndexCastOp>(loc, indexType, cropWI32);
+    mlir::Value cropH = rewriter.create<mlir::arith::IndexCastOp>(loc, indexType, cropHI32);
 
     auto ubMap = mlir::AffineMap::get(1, 0, rewriter.getAffineDimExpr(0), rewriter.getContext());
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,4 +1,5 @@
 #include "utils.h"
+#include <cstdlib>
 #include <filesystem>
 
 namespace picceler::utils {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,49 +1,50 @@
 #include "utils.h"
+#include <filesystem>
 
 namespace picceler::utils {
 
-std::string expandTilde(const std::string& inputPath) {
-    if (inputPath.empty() || inputPath[0] != '~') {
-        return inputPath;
-    }
+std::string expandTilde(const std::string &inputPath) {
+  if (inputPath.empty() || inputPath[0] != '~') {
+    return inputPath;
+  }
 
-    std::filesystem::path homePath;
+  std::filesystem::path homePath;
 
 #ifdef _WIN32
-    const char* userProfile = std::getenv("USERPROFILE");
-    if (!userProfile) {
-        const char* hd = std::getenv("HOMEDRIVE");
-        const char* hp = std::getenv("HOMEPATH");
-        if (hd && hp) {
-            homePath = std::string(hd) + std::string(hp);
-        } else {
-            return inputPath;
-        }
+  const char *userProfile = std::getenv("USERPROFILE");
+  if (!userProfile) {
+    const char *hd = std::getenv("HOMEDRIVE");
+    const char *hp = std::getenv("HOMEPATH");
+    if (hd && hp) {
+      homePath = std::string(hd) + std::string(hp);
     } else {
-        homePath = userProfile;
+      return inputPath;
     }
+  } else {
+    homePath = userProfile;
+  }
 #else
-    const char* homeEnv = std::getenv("HOME");
-    if (homeEnv) {
-        homePath = homeEnv;
+  const char *homeEnv = std::getenv("HOME");
+  if (homeEnv) {
+    homePath = homeEnv;
+  } else {
+    struct passwd *pw = getpwuid(getuid());
+    if (pw) {
+      homePath = pw->pw_dir;
     } else {
-        struct passwd* pw = getpwuid(getuid());
-        if (pw) {
-            homePath = pw->pw_dir;
-        } else {
-            return inputPath;
-        }
+      return inputPath;
     }
+  }
 #endif
-    std::string remainder = inputPath.substr(1);
+  std::string remainder = inputPath.substr(1);
 
-    if (!remainder.empty() && (remainder[0] == '/' || remainder[0] == '\\')) {
-        remainder = remainder.substr(1);
-    }
+  if (!remainder.empty() && (remainder[0] == '/' || remainder[0] == '\\')) {
+    remainder = remainder.substr(1);
+  }
 
-    homePath /= remainder;
+  homePath /= remainder;
 
-    return homePath.string();
+  return homePath.string();
 }
 
 } // namespace picceler::utils

--- a/tests/unit/src/lexer_tests.cpp
+++ b/tests/unit/src/lexer_tests.cpp
@@ -6,34 +6,34 @@ protected:
   void SetUp() override {}
   void TearDown() override {}
 
-  picceler::Lexer lexer;
+  picceler::Lexer _lexer;
 };
 
 TEST_F(LexerTest, EmptyInput) {
-  auto res = lexer.setSource("data/empty.pic");
+  auto res = _lexer.setSource("data/empty.pic");
   if (!res)
     FAIL() << res.error().message();
 
-  auto tokensRes = lexer.tokenizeAll();
+  auto tokensRes = _lexer.tokenizeAll();
   if (!tokensRes)
     FAIL() << tokensRes.error().message();
-  auto tokens = tokensRes.value();
+  const auto &tokens = tokensRes.value();
 
   ASSERT_EQ(tokens.size(), 1);
   EXPECT_EQ(tokens[0].type(), picceler::Token::Type::EOF_TOKEN);
 }
 
 TEST_F(LexerTest, LoadImageStatement) {
-  auto res = lexer.setSource("data/load_image.pic");
+  auto res = _lexer.setSource("data/load_image.pic");
   if (!res)
     FAIL() << res.error().message();
 
   // file contents:
   // img = load_image("cat.jpg")
-  auto tokensRes = lexer.tokenizeAll();
+  auto tokensRes = _lexer.tokenizeAll();
   if (!tokensRes)
     FAIL() << tokensRes.error().message();
-  auto tokens = tokensRes.value();
+  const auto &tokens = tokensRes.value();
 
   ASSERT_GE(tokens.size(), 7); // img, =, load_image, (, "cat.jpg", ), EOF
 
@@ -59,14 +59,14 @@ TEST_F(LexerTest, LoadImageStatement) {
 }
 
 TEST_F(LexerTest, NumbersParsing) {
-  auto res = lexer.setSource("data/numbers.pic");
+  auto res = _lexer.setSource("data/numbers.pic");
   if (!res)
     FAIL() << res.error().message();
 
-  auto tokensRes = lexer.tokenizeAll();
+  auto tokensRes = _lexer.tokenizeAll();
   if (!tokensRes)
     FAIL() << tokensRes.error().message();
-  auto tokens = tokensRes.value();
+  const auto &tokens = tokensRes.value();
 
   std::vector<std::string> numbers;
   for (const auto &t : tokens) {
@@ -81,31 +81,31 @@ TEST_F(LexerTest, NumbersParsing) {
 }
 
 TEST_F(LexerTest, KernelTokenSequence) {
-  auto res = lexer.setSource("data/kernel.pic");
+  auto res = _lexer.setSource("data/kernel.pic");
   if (!res)
     FAIL() << res.error().message();
 
-  auto tokensRes = lexer.tokenizeAll();
+  auto tokensRes = _lexer.tokenizeAll();
   if (!tokensRes)
     FAIL() << tokensRes.error().message();
-  auto tokens = tokensRes.value();
+  const auto &tokens = tokensRes.value();
 
   // Expect sequence: IDENTIFIER, '=', '[', '[', NUMBER(1), ',', NUMBER(2), ']', ',', '[', NUMBER(3), ',', NUMBER(4),
   // ']', ']', EOF
   std::vector<std::string> seq;
   for (const auto &t : tokens) {
-    if (t.type() == picceler::Token::Type::L_BRACKET)
+    switch (t.type()) {
+    case picceler::Token::Type::IDENTIFIER:
+    case picceler::Token::Type::ASSIGN:
+    case picceler::Token::Type::L_BRACKET:
+    case picceler::Token::Type::R_BRACKET:
+    case picceler::Token::Type::COMMA:
+    case picceler::Token::Type::NUMBER:
       seq.push_back(t.value());
-    else if (t.type() == picceler::Token::Type::R_BRACKET)
-      seq.push_back(t.value());
-    else if (t.type() == picceler::Token::Type::COMMA)
-      seq.push_back(t.value());
-    else if (t.type() == picceler::Token::Type::NUMBER)
-      seq.push_back(t.value());
-    else if (t.type() == picceler::Token::Type::IDENTIFIER)
-      seq.push_back(t.value());
-    else if (t.type() == picceler::Token::Type::ASSIGN)
-      seq.push_back(t.value());
+      break;
+    default:
+      break;
+    }
   }
 
   std::vector<std::string> expected = {"k", "=", "[", "[", "1", ",", "2", "]", ",", "[", "3", ",", "4", "]", "]"};
@@ -117,14 +117,14 @@ TEST_F(LexerTest, KernelTokenSequence) {
 }
 
 TEST_F(LexerTest, IdentifiersAndUnderscores) {
-  auto res = lexer.setSource("data/identifiers.pic");
+  auto res = _lexer.setSource("data/identifiers.pic");
   if (!res)
     FAIL() << res.error().message();
 
-  auto tokensRes = lexer.tokenizeAll();
+  auto tokensRes = _lexer.tokenizeAll();
   if (!tokensRes)
     FAIL() << tokensRes.error().message();
-  auto tokens = tokensRes.value();
+  const auto &tokens = tokensRes.value();
 
   // Check presence of identifier names
   bool foundMyVar = false;
@@ -146,18 +146,18 @@ TEST_F(LexerTest, IdentifiersAndUnderscores) {
 }
 
 TEST_F(LexerTest, StringParsingAndPeek) {
-  auto res = lexer.setSource("data/strings.pic");
+  auto res = _lexer.setSource("data/strings.pic");
   if (!res)
     FAIL() << res.error().message();
 
-  auto peekRes = lexer.peekToken();
+  auto peekRes = _lexer.peekToken();
   if (!peekRes)
     FAIL() << peekRes.error().message();
   // peek should return first token (identifier 's') without consuming
   EXPECT_EQ(peekRes->type(), picceler::Token::Type::IDENTIFIER);
   EXPECT_EQ(peekRes->value(), "s");
 
-  auto nextRes = lexer.nextToken();
+  auto nextRes = _lexer.nextToken();
   if (!nextRes)
     FAIL() << nextRes.error().message();
   EXPECT_EQ(nextRes->type(), picceler::Token::Type::IDENTIFIER);
@@ -165,10 +165,10 @@ TEST_F(LexerTest, StringParsingAndPeek) {
 
   // advance to string token
   // consume '=', identifier already consumed
-  auto eqToken = lexer.nextToken(); // consume '='
+  auto eqToken = _lexer.nextToken(); // consume '='
   if (!eqToken)
     FAIL() << eqToken.error().message();
-  auto strRes = lexer.nextToken();
+  auto strRes = _lexer.nextToken();
   if (!strRes)
     FAIL() << strRes.error().message();
   EXPECT_EQ(strRes->type(), picceler::Token::Type::STRING);
@@ -176,14 +176,14 @@ TEST_F(LexerTest, StringParsingAndPeek) {
 }
 
 TEST_F(LexerTest, UnknownCharacterProducesUnknownToken) {
-  auto res = lexer.setSource("data/weird.pic");
+  auto res = _lexer.setSource("data/weird.pic");
   if (!res)
     FAIL() << res.error().message();
 
-  auto tokensRes = lexer.tokenizeAll();
+  auto tokensRes = _lexer.tokenizeAll();
   if (!tokensRes)
     FAIL() << tokensRes.error().message();
-  auto tokens = tokensRes.value();
+  const auto &tokens = tokensRes.value();
 
   bool foundUnknown = false;
   for (const auto &t : tokens) {

--- a/tests/unit/src/parser_tests.cpp
+++ b/tests/unit/src/parser_tests.cpp
@@ -6,97 +6,97 @@ protected:
   void SetUp() override {}
   void TearDown() override {}
 
-  picceler::Parser parser;
+  picceler::Parser _parser;
 };
 
 TEST_F(ParserTest, BadKernelMissingCommaFails) {
-  auto result = parser.setSource("data/bad_kernel_missing_comma.pic");
+  auto result = _parser.setSource("data/bad_kernel_missing_comma.pic");
   if (!result)
     FAIL() << result.error().message();
 
-  auto astRes = parser.parse();
+  auto astRes = _parser.parse();
   EXPECT_FALSE(astRes.has_value());
 }
 
 TEST_F(ParserTest, BadKernelMissingBracketFails) {
-  auto result = parser.setSource("data/bad_kernel_missing_bracket.pic");
+  auto result = _parser.setSource("data/bad_kernel_missing_bracket.pic");
   if (!result)
     FAIL() << result.error().message();
 
-  auto astRes = parser.parse();
+  auto astRes = _parser.parse();
   EXPECT_FALSE(astRes.has_value());
 }
 
 TEST_F(ParserTest, BadKernelBadNumberFails) {
-  auto result = parser.setSource("data/bad_kernel_bad_number.pic");
+  auto result = _parser.setSource("data/bad_kernel_bad_number.pic");
   if (!result)
     FAIL() << result.error().message();
 
-  auto astRes = parser.parse();
+  auto astRes = _parser.parse();
   EXPECT_FALSE(astRes.has_value());
 }
 
 TEST_F(ParserTest, EmptyInput) {
-  auto result = parser.setSource("data/empty.pic");
+  auto result = _parser.setSource("data/empty.pic");
   if (!result)
     FAIL() << result.error().message();
 
-  auto astRes = parser.parse();
+  auto astRes = _parser.parse();
   if (!astRes)
     FAIL() << astRes.error().message();
   auto ast = std::move(astRes.value());
 
   ASSERT_NE(ast, nullptr);
-  EXPECT_EQ(ast->statements.size(), 0);
+  EXPECT_EQ(ast->statements().size(), 0);
 }
 
 TEST_F(ParserTest, LoadImageStatement) {
-  auto result = parser.setSource("data/load_image.pic");
+  auto result = _parser.setSource("data/load_image.pic");
   if (!result)
     FAIL() << result.error().message();
 
   // file contents:
   // img = load_image("cat.jpg")
-  auto astRes = parser.parse();
+  auto astRes = _parser.parse();
   if (!astRes)
     FAIL() << astRes.error().message();
   auto ast = std::move(astRes.value());
 
   ASSERT_NE(ast, nullptr);
-  ASSERT_EQ(ast->statements.size(), 1);
-  auto assignment = dynamic_cast<picceler::AssignmentNode *>(ast->statements[0].get());
+  ASSERT_EQ(ast->statements().size(), 1);
+  auto assignment = dynamic_cast<picceler::AssignmentNode *>(ast->statements()[0]);
   ASSERT_NE(assignment, nullptr);
-  EXPECT_EQ(assignment->lhs->name, "img");
-  auto call = dynamic_cast<picceler::CallNode *>(assignment->rhs.get());
+  EXPECT_EQ(assignment->lhs()->name(), "img");
+  auto call = dynamic_cast<picceler::CallNode *>(assignment->rhs());
   ASSERT_NE(call, nullptr);
-  EXPECT_EQ(call->callee, "load_image");
-  ASSERT_EQ(call->arguments.size(), 1);
-  auto strArg = dynamic_cast<picceler::StringNode *>(call->arguments[0].get());
+  EXPECT_EQ(call->callee(), "load_image");
+  ASSERT_EQ(call->arguments().size(), 1);
+  auto strArg = dynamic_cast<picceler::StringNode *>(call->arguments()[0]);
   ASSERT_NE(strArg, nullptr);
-  EXPECT_EQ(strArg->value, "cat.jpg");
+  EXPECT_EQ(strArg->value(), "cat.jpg");
 }
 
 TEST_F(ParserTest, RotateNegativeAngleParses) {
-  auto result = parser.setSource("data/rotate_negative.pic");
+  auto result = _parser.setSource("data/rotate_negative.pic");
   if (!result)
     FAIL() << result.error().message();
 
-  auto astRes = parser.parse();
+  auto astRes = _parser.parse();
   if (!astRes)
     FAIL() << astRes.error().message();
   auto ast = std::move(astRes.value());
 
   ASSERT_NE(ast, nullptr);
-  ASSERT_EQ(ast->statements.size(), 1);
-  auto assignment = dynamic_cast<picceler::AssignmentNode *>(ast->statements[0].get());
+  ASSERT_EQ(ast->statements().size(), 1);
+  auto assignment = dynamic_cast<picceler::AssignmentNode *>(ast->statements()[0]);
   ASSERT_NE(assignment, nullptr);
 
-  auto call = dynamic_cast<picceler::CallNode *>(assignment->rhs.get());
+  auto call = dynamic_cast<picceler::CallNode *>(assignment->rhs());
   ASSERT_NE(call, nullptr);
-  EXPECT_EQ(call->callee, "rotate");
-  ASSERT_EQ(call->arguments.size(), 2);
+  EXPECT_EQ(call->callee(), "rotate");
+  ASSERT_EQ(call->arguments().size(), 2);
 
-  auto angleNode = dynamic_cast<picceler::NumberNode *>(call->arguments[1].get());
+  auto angleNode = dynamic_cast<picceler::NumberNode *>(call->arguments()[1]);
   ASSERT_NE(angleNode, nullptr);
-  EXPECT_EQ(angleNode->value, -90);
+  EXPECT_EQ(angleNode->value(), -90);
 }


### PR DESCRIPTION
This PR is the result of enabling clang tidy in the build process and fixing every finding of it. Also modified a bit `.clang-tidy` to have a more refined set of rules to follow. Most of the changes do not need proper understanding and are just c++ micro-optimizations, some more major changes in parser/lexer changes

The PR also adds better verbosity in the code, replacing `size_t line, size_t column` with a `Location` struct, removes unused includes, fixes some copilot reviews.

Also introduces a nice design with `std::views::transform` for lazy evaluation to return the vector of unique_ptr<T> but to expose them as T* to the callee