### PR TITLE
Add print functionality

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,5 +19,8 @@ conditions to reproduce
 **Expected behavior**
 A clear and concise description of what you expected to happen.
 
+**Proposed solution**
+A more detailed or technical description of how you expect the fixed code to look like.
+
 **Additional context**
 Add any other context about the problem here.

--- a/examples/print.pic
+++ b/examples/print.pic
@@ -1,0 +1,8 @@
+def main() {
+    img_path = "~/Pictures/cat.png"
+    print("Loading image {}\n", img_path)
+    img = load_image(img_path)
+    number = read_number("Please input a number:")
+    print("The number you entered is {} and the image path is {}\n", number, img_path)
+    
+}

--- a/include/ast.h
+++ b/include/ast.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "error.h"
+
 #include <vector>
 #include <string>
 #include <optional>
@@ -17,8 +19,9 @@ template <typename T> auto getRawPointers(const std::vector<std::unique_ptr<T>> 
  */
 class ASTNode {
 public:
-  ASTNode() = default;
+  ASTNode() : _location() {}
   virtual ~ASTNode() = default;
+  ASTNode(Location loc) : _location(loc) {}
 
   ASTNode(const ASTNode &) = delete;
   ASTNode &operator=(const ASTNode &) = delete;
@@ -26,6 +29,11 @@ public:
   ASTNode &operator=(ASTNode &&) = default;
 
   virtual std::string toString() const = 0;
+
+  Location location() const { return _location; }
+
+private:
+  Location _location;
 };
 
 /**
@@ -34,6 +42,8 @@ public:
 
 class ModuleNode : public ASTNode {
 public:
+  ModuleNode(Location loc) : ASTNode(loc), _statements() {}
+
   auto statements() const { return getRawPointers(_statements); }
 
   void normalizeTopLevelStatements();
@@ -52,7 +62,7 @@ private:
  */
 class FunctionNode : public ASTNode {
 public:
-  FunctionNode(std::string name) : _name(std::move(name)) {}
+  FunctionNode(Location loc, std::string name) : ASTNode(loc), _name(std::move(name)) {}
 
   const std::string &name() const { return _name; }
   const auto &parameters() const { return _parameters; }
@@ -77,8 +87,8 @@ private:
  */
 class VariableNode : public ASTNode {
 public:
-  VariableNode(std::string name, std::optional<std::string> type = std::nullopt)
-      : _name(std::move(name)), _type(std::move(type)) {}
+  VariableNode(Location loc, std::string name, std::optional<std::string> type = std::nullopt)
+      : ASTNode(loc), _name(std::move(name)), _type(std::move(type)) {}
 
   const std::string &name() const { return _name; }
   const std::optional<std::string> &type() const { return _type; }
@@ -95,7 +105,7 @@ private:
  */
 class StringNode : public ASTNode {
 public:
-  StringNode(std::string value) : _value(std::move(value)) {}
+  StringNode(Location loc, std::string value) : ASTNode(loc), _value(std::move(value)) {}
 
   const std::string &value() const { return _value; }
 
@@ -110,7 +120,7 @@ private:
  */
 class NumberNode : public ASTNode {
 public:
-  NumberNode(double value) : _value(value) {}
+  NumberNode(Location loc, double value) : ASTNode(loc), _value(value) {}
 
   double value() const { return _value; }
 
@@ -125,8 +135,8 @@ private:
  */
 class AssignmentNode : public ASTNode {
 public:
-  AssignmentNode(std::unique_ptr<VariableNode> lhs, std::unique_ptr<ASTNode> rhs)
-      : _lhs(std::move(lhs)), _rhs(std::move(rhs)) {}
+  AssignmentNode(Location loc, std::unique_ptr<VariableNode> lhs, std::unique_ptr<ASTNode> rhs)
+      : ASTNode(loc), _lhs(std::move(lhs)), _rhs(std::move(rhs)) {}
 
   VariableNode *lhs() const { return _lhs.get(); }
   ASTNode *rhs() const { return _rhs.get(); }
@@ -143,7 +153,7 @@ private:
  */
 class CallNode : public ASTNode {
 public:
-  CallNode(std::string callee) : _callee(std::move(callee)), _arguments() {}
+  CallNode(Location loc, std::string callee) : ASTNode(loc), _callee(std::move(callee)), _arguments() {}
 
   const std::string &callee() const { return _callee; }
   auto arguments() const { return getRawPointers(_arguments); }
@@ -163,6 +173,7 @@ private:
 
 class KernelNode : public ASTNode {
 public:
+  KernelNode(Location loc) : ASTNode(loc), _rows() {}
   const std::vector<std::vector<double>> &rows() const { return _rows; }
 
   void addRow(const std::vector<double> &row) { _rows.push_back(row); }

--- a/include/lexer.h
+++ b/include/lexer.h
@@ -217,6 +217,9 @@ private:
   Result<Token> readSymbol(std::pair<size_t, size_t> start);
 
 private:
+  std::string unescapeString(std::string &&string) const;
+
+private:
   std::ifstream _file;
   std::string _buffer;
   size_t _position;

--- a/include/mlir_gen.h
+++ b/include/mlir_gen.h
@@ -38,9 +38,10 @@ public:
   /**
    * @brief Generates MLIR code from the given AST root node.
    * @param root The root node of the AST.
+   * @param sourceFile The source file name for location tracking.
    * @return The generated MLIR module operation.
    */
-  mlir::ModuleOp generate(ModuleNode *root);
+  mlir::ModuleOp generate(ModuleNode *root, const std::string &sourceFile);
 
 private:
   /**
@@ -122,6 +123,7 @@ private:
   mlir::OpBuilder _builder;
   std::vector<NamedVariableTable> _scopedVariableTable;
   std::unordered_map<std::string, GeneratorFunction> _functionTable;
+  std::string _sourceFile;
 };
 
 } // namespace picceler

--- a/lib/include/runtime.h
+++ b/lib/include/runtime.h
@@ -18,6 +18,10 @@ picceler::Image *piccelerCreateImage(uint32_t width, uint32_t height);
 void *piccelerReadString(const char *prompt);
 double piccelerReadNumber(const char *prompt);
 
+void piccelerPrintString(const char *str);
+
+void piccelerPrintFloat64(double value);
+
 /**
  * \}
  */

--- a/lib/src/print.cpp
+++ b/lib/src/print.cpp
@@ -1,0 +1,7 @@
+#include "runtime.h"
+
+#include <print>
+
+void piccelerPrintString(const char *str) { std::print(std::cout, "{}", str); }
+
+void piccelerPrintFloat64(double value) { std::print(std::cout, "{}", value); }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library(PiccelerOps STATIC
     ops/erode.cpp
     ops/blend.cpp
     ops/diff.cpp
+    ops/print.cpp
 )
 
 target_link_libraries(PiccelerOps PUBLIC

--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -39,7 +39,7 @@ bool ModuleNode::wrapTopLevelStatementsInMain() {
   if (!hasMain) {
     if (!onlyFunctions) {
       spdlog::warn("No 'main' functions found, implicit 'main' will be generated to wrap the top-level statements");
-      auto mainFunc = std::make_unique<FunctionNode>("main");
+      auto mainFunc = std::make_unique<FunctionNode>(Location(0, 0), "main");
       for (auto &stmt : _statements) {
         auto stmtPtr = stmt.get();
         if (!dynamic_cast<FunctionNode *>(stmtPtr)) {

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -91,7 +91,7 @@ bool Compiler::run() {
   ast->normalizeTopLevelStatements();
 
   spdlog::info("Generating initial MLIR");
-  auto module = _mlirGen.generate(ast.get());
+  auto module = _mlirGen.generate(ast.get(), inputFile);
   spdlog::info("Finished generating initial MLIR");
   module->dump();
   spdlog::info("Running pass manager");

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -223,6 +223,7 @@ Result<Token> Lexer::readString(std::pair<size_t, size_t> start) {
   while (!eof() && peek() != '"') {
     value += get();
   }
+  value = unescapeString(std::move(value));
   if (!eof())
     get(); // consume the closing quote
   return Token{Token::Type::STRING, value, Location{start}};
@@ -258,6 +259,49 @@ Result<Token> Lexer::readSymbol(std::pair<size_t, size_t> start) {
   default:
     return Token{Token::Type::UNKNOWN, std::string(1, ch), Location{start}};
   }
+}
+
+std::string Lexer::unescapeString(std::string &&string) const {
+  std::string unescaped;
+  unescaped.reserve(string.size());
+
+  for (size_t i = 0; i < string.size(); ++i) {
+    if (string[i] == '\\' && i + 1 < string.size()) {
+      switch (string[i + 1]) {
+      case 'n':
+        unescaped += '\n';
+        break; // Newline (0x0A)
+      case 't':
+        unescaped += '\t';
+        break; // Tab (0x09)
+      case 'r':
+        unescaped += '\r';
+        break; // Carriage Return (0x0D)
+      case '\\':
+        unescaped += '\\';
+        break; // Literal Backslash
+      case '"':
+        unescaped += '"';
+        break; // Double Quote
+      case '\'':
+        unescaped += '\'';
+        break; // Single Quote
+      case '0':
+        unescaped += '\0';
+        break; // Null Byte
+      default:
+        // If it's an unrecognized escape (e.g. \a), keep the backslash and character
+        unescaped += '\\';
+        unescaped += string[i + 1];
+        break;
+      }
+      ++i;
+    } else {
+      unescaped += string[i];
+    }
+  }
+
+  return unescaped;
 }
 
 std::ostream &operator<<(std::ostream &os, const Token &token) {

--- a/src/mlir_gen.cpp
+++ b/src/mlir_gen.cpp
@@ -67,7 +67,7 @@ mlir::Value coerceValueToInt64(mlir::OpBuilder &builder, mlir::Location loc, mli
 }
 
 MLIRGen::MLIRGen(mlir::MLIRContext *context)
-    : _context(context), _builder(_context), _scopedVariableTable(), _functionTable() {
+    : _context(context), _builder(_context), _scopedVariableTable(), _functionTable(), _sourceFile("Undefined") {
   enterScope("Global"); // Enter the global scope
 }
 
@@ -149,12 +149,8 @@ void MLIRGen::defineUserFunctions(mlir::ModuleOp module, ModuleNode *root) {
   }
 }
 
-/**
- * @brief Generates MLIR code from the given AST root node.
- * @param root The root node of the AST.
- * @return The generated MLIR module operation.
- */
-mlir::ModuleOp MLIRGen::generate(ModuleNode *root) {
+mlir::ModuleOp MLIRGen::generate(ModuleNode *root, const std::string &sourceFile) {
+  _sourceFile = sourceFile;
   auto module = mlir::ModuleOp::create(_builder.getUnknownLoc());
   registerBuiltinFunctions();
 
@@ -301,7 +297,8 @@ mlir::Value MLIRGen::emitString(StringNode *node) {
   spdlog::debug("Emitting MLIR for string: {}", node->toString());
   auto stringType = _builder.getType<StringType>();
   auto valueAttr = mlir::StringAttr::get(_context, node->value());
-  return _builder.create<StringConstOp>(_builder.getUnknownLoc(), stringType, valueAttr);
+  auto someLocation = mlir::FileLineColLoc::get(_context, "source.pic", 0, 0); // Placeholder location
+  return _builder.create<StringConstOp>(someLocation, stringType, valueAttr);
 }
 
 mlir::Value MLIRGen::emitNumber(NumberNode *node) {
@@ -424,6 +421,13 @@ void MLIRGen::registerBuiltinFunctions() {
     auto &prompt = args[0];
     auto callOp = _builder.create<ReadStringOp>(loc, resultType, prompt);
     return callOp.getResult();
+  };
+  _functionTable["print"] = [&](mlir::Location loc, const std::vector<mlir::Value> &args) {
+    auto &fmt = args[0];
+    llvm::ArrayRef<mlir::Value> variadicArgs(args.data() + 1, args.size() - 1);
+
+    _builder.create<PrintOp>(loc, fmt, variadicArgs);
+    return mlir::Value(); // Return an empty value for void functions
   };
 }
 

--- a/src/ops/print.cpp
+++ b/src/ops/print.cpp
@@ -1,0 +1,16 @@
+#include "ops.h"
+
+#include "spdlog/spdlog.h"
+
+namespace picceler {
+
+mlir::LogicalResult PrintOp::verify() {
+  auto fmt = getFmt();
+  auto producer = fmt.getDefiningOp();
+  if (!producer || !llvm::isa<StringConstOp>(producer)) {
+    spdlog::error("fmt operand of print must be compile time constant");
+    return mlir::failure();
+  }
+  return mlir::success();
+}
+} // namespace picceler

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -23,7 +23,7 @@ Result<std::vector<Token>> Parser::getTokens() {
 
 Result<std::unique_ptr<ModuleNode>> Parser::parse() {
   spdlog::info("Starting parsing process");
-  auto module = std::make_unique<ModuleNode>();
+  auto module = std::make_unique<ModuleNode>(Location(0, 0));
   while (true) {
     auto stmt = parseStatement();
     if (!stmt) {
@@ -96,7 +96,7 @@ Result<std::unique_ptr<ASTNode>> Parser::parseFunctionDefinition([[maybe_unused]
     return std::unexpected(CompileError{"Expected function name after 'def'", nameTokenResult->location()});
   }
   auto funcName = nameTokenResult->value();
-  auto funcNode = std::make_unique<FunctionNode>(funcName);
+  auto funcNode = std::make_unique<FunctionNode>(nameTokenResult->location(), funcName);
   const auto &lParenTokenResult = _lexer.nextToken(); // consume '('
   if (!lParenTokenResult) {
     spdlog::error("{}", lParenTokenResult.error().message());
@@ -241,7 +241,8 @@ Result<std::unique_ptr<ASTNode>> Parser::parseAssignment(const Token &identifier
     return std::unexpected(CompileError{"Left-hand side of assignment must be a variable"});
   }
   auto leftVarNode = std::unique_ptr<VariableNode>(static_cast<VariableNode *>(leftVar.release()));
-  auto assignNode = std::make_unique<AssignmentNode>(std::move(leftVarNode), std::move(exprVar));
+  auto assignNode =
+      std::make_unique<AssignmentNode>(leftVarNode->location(), std::move(leftVarNode), std::move(exprVar));
   return assignNode;
 }
 
@@ -256,7 +257,7 @@ Result<std::unique_ptr<ASTNode>> Parser::parseCall(const Token &identifier) {
   if (lparenToken != Token::Type::L_PAREN) {
     return std::unexpected(CompileError{std::format("Expected '(' after function name"), lparenToken.location()});
   }
-  auto callNode = std::make_unique<CallNode>(identifier.value());
+  auto callNode = std::make_unique<CallNode>(identifier.location(), identifier.value());
 
   while (true) {
     auto nextTokenResult = _lexer.peekToken();
@@ -343,6 +344,7 @@ Result<std::unique_ptr<ASTNode>> Parser::parseExpression() {
 Result<std::unique_ptr<ASTNode>> Parser::parseVariable(const Token &identifier) {
   spdlog::debug("Parsing variable");
   std::string varName = identifier.value();
+  Location loc = identifier.location();
   // If the passed token is not an identifier, consume the next token
   if (identifier != Token::Type::IDENTIFIER) {
     auto identifierResult = _lexer.nextToken();
@@ -351,9 +353,10 @@ Result<std::unique_ptr<ASTNode>> Parser::parseVariable(const Token &identifier) 
       return std::unexpected(CompileError{"Failed to consume identifier token in variable"});
     }
     varName = identifierResult->value();
+    loc = identifierResult->location();
   }
 
-  auto varNode = std::make_unique<VariableNode>(varName, std::nullopt);
+  auto varNode = std::make_unique<VariableNode>(loc, varName, std::nullopt);
   return varNode;
 }
 
@@ -369,7 +372,7 @@ Result<std::unique_ptr<ASTNode>> Parser::parseKernel() {
     return std::unexpected(CompileError{"Expected '['", lbracketToken.location()});
   }
 
-  auto kernelNode = std::make_unique<KernelNode>();
+  auto kernelNode = std::make_unique<KernelNode>(lbracketToken.location());
 
   while (true) {
     auto peekedtokenResult = _lexer.peekToken();
@@ -517,7 +520,7 @@ Result<std::unique_ptr<ASTNode>> Parser::parseString() {
     return std::unexpected(CompileError{"Expected string", token.location()});
   }
   // TODO: Implement a compiler flag to let the user not expand tilde if it is not needed
-  auto strNode = std::make_unique<StringNode>(utils::expandTilde(token.value()));
+  auto strNode = std::make_unique<StringNode>(token.location(), utils::expandTilde(token.value()));
   return strNode;
 }
 
@@ -534,7 +537,7 @@ Result<std::unique_ptr<ASTNode>> Parser::parseNumber() {
   }
   std::unique_ptr<NumberNode> numNode = nullptr;
   try {
-    numNode = std::make_unique<NumberNode>(std::stod(token.value()));
+    numNode = std::make_unique<NumberNode>(token.location(), std::stod(token.value()));
   } catch (const std::invalid_argument &) {
     return std::unexpected(CompileError{std::format("Invalid double literal '{}'", token.value()), token.location()});
   } catch (const std::out_of_range &) {

--- a/src/picceler_ops_to_func_calls_pass.cpp
+++ b/src/picceler_ops_to_func_calls_pass.cpp
@@ -1,5 +1,7 @@
 #include "passes.h"
 
+#include "spdlog/spdlog.h"
+
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Transforms/DialectConversion.h"
@@ -161,6 +163,91 @@ struct ReadStringToCall : mlir::OpConversionPattern<ReadStringOp> {
   }
 };
 
+struct PrintToCalls : mlir::OpConversionPattern<PrintOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  mlir::LogicalResult matchAndRewrite(PrintOp op, PrintOpAdaptor adaptor,
+                                      mlir::ConversionPatternRewriter &rewriter) const override {
+    auto module = op->getParentOfType<mlir::ModuleOp>();
+    auto ctx = rewriter.getContext();
+    auto loc = op.getLoc();
+
+    auto stringType = StringType::get(ctx);
+
+    auto fmtValue = adaptor.getFmt();
+    auto stringProducer = fmtValue.getDefiningOp<StringConstOp>();
+    if (!stringProducer) {
+      spdlog::error("PrintOp format value is not a StringConstOp");
+      return mlir::failure();
+    }
+    auto args = adaptor.getArgs();
+
+    std::string fmt = stringProducer.getValue().str();
+    spdlog::debug("PrintOp format value: {}", fmt);
+
+    std::vector<std::string> splitFmt = splitFormatString(fmt);
+    size_t argsIndex = 0;
+    for (const auto &part : splitFmt) {
+      spdlog::debug("Split format part: {}", part);
+      if (!part.empty()) {
+        callFormatStringLiteral(rewriter, loc, part);
+      }
+      if (argsIndex < args.size()) {
+        auto rawVal = args[argsIndex];
+        auto type = rawVal.getType();
+        if (auto floatVal = llvm::dyn_cast<mlir::TypedValue<mlir::Float64Type>>(rawVal)) {
+          callFormatFloat64(rewriter, loc, floatVal);
+        } else if (auto stringVal = llvm::dyn_cast<mlir::TypedValue<StringType>>(rawVal)) {
+          callFormatString(rewriter, loc, stringVal);
+        } else {
+          op.emitOpError("Unsupported argument type for print format!");
+          return mlir::failure();
+        }
+        argsIndex++;
+      }
+    }
+    rewriter.eraseOp(stringProducer);
+    rewriter.eraseOp(op);
+    return mlir::success();
+  }
+
+  void callFormatStringLiteral(mlir::ConversionPatternRewriter &rewriter, mlir::Location loc,
+                               const std::string &str) const {
+    auto stringType = StringType::get(rewriter.getContext());
+    auto string = rewriter.create<StringConstOp>(loc, stringType, mlir::StringAttr::get(rewriter.getContext(), str));
+    callFormatString(rewriter, loc, string.getResult());
+  }
+  void callFormatString(mlir::ConversionPatternRewriter &rewriter, mlir::Location loc,
+                        mlir::TypedValue<StringType> value) const {
+    auto module = rewriter.getInsertionBlock()->getParentOp()->getParentOfType<mlir::ModuleOp>();
+    auto funcOp = ensureRuntimeFunc(module, "piccelerPrintString", {value.getType()}, {}, rewriter, loc);
+    rewriter.create<mlir::func::CallOp>(loc, funcOp, mlir::ValueRange{value});
+  }
+  void callFormatFloat64(mlir::ConversionPatternRewriter &rewriter, mlir::Location loc,
+                         mlir::TypedValue<mlir::Float64Type> value) const {
+    auto module = rewriter.getInsertionBlock()->getParentOp()->getParentOfType<mlir::ModuleOp>();
+    auto funcOp = ensureRuntimeFunc(module, "piccelerPrintFloat64", {value.getType()}, {}, rewriter, loc);
+    rewriter.create<mlir::func::CallOp>(loc, funcOp, mlir::ValueRange{value});
+  }
+
+  std::vector<std::string> splitFormatString(const std::string &fmt) const {
+    std::vector<std::string> parts;
+    size_t start = 0;
+
+    while (start < fmt.size()) {
+      size_t pos = fmt.find("{}", start);
+      if (pos == std::string::npos) {
+        parts.push_back(fmt.substr(start));
+        break;
+      }
+
+      parts.push_back(fmt.substr(start, pos - start));
+      start = pos + 2;
+    }
+    return parts;
+  }
+};
+
 #define GEN_PASS_DEF_PICCELEROPSTOFUNCCALLS
 #include "piccelerPasses.h.inc"
 
@@ -174,12 +261,13 @@ struct PiccelerOpsToFuncCallsPass : public impl::PiccelerOpsToFuncCallsBase<Picc
     mlir::ModuleOp module = getOperation();
 
     mlir::ConversionTarget target(getContext());
-    target.addLegalOp<mlir::ModuleOp>();
+    target.addLegalOp<mlir::ModuleOp, StringConstOp>();
     target.addLegalDialect<mlir::func::FuncDialect>();
-    target.addIllegalOp<LoadImageOp, ShowImageOp, SaveImageOp, ReadNumberOp, ReadStringOp>();
+    target.addIllegalOp<LoadImageOp, ShowImageOp, SaveImageOp, ReadNumberOp, ReadStringOp, PrintOp>();
 
     mlir::RewritePatternSet patterns(&getContext());
-    patterns.add<LoadImageToCall, ShowImageToCall, SaveImageToCall, ReadNumberToCall, ReadStringToCall>(&getContext());
+    patterns.add<LoadImageToCall, ShowImageToCall, SaveImageToCall, ReadNumberToCall, ReadStringToCall, PrintToCalls>(
+        &getContext());
 
     if (mlir::failed(mlir::applyPartialConversion(module, target, std::move(patterns)))) {
       signalPassFailure();

--- a/tablegen/ops.td
+++ b/tablegen/ops.td
@@ -43,6 +43,17 @@ def Picceler_ShowImageOp : Op<PiccelerDialect, "show_image", []> {
   let results = (outs);
 }
 
+def Picceler_PrintOp : Op<PiccelerDialect, "print", []> {
+  let summary = "Print anything to the console, alike std::format";
+  let arguments = (ins 
+  Picceler_StringType:$fmt, 
+  Variadic<AnyType>:$args
+  );
+  let results = (outs);
+
+  let hasVerifier = 1;
+}
+
 def Picceler_BrightnessOp : Op<PiccelerDialect, "brightness", []> {
   let summary = "Adjust the brightness of an image";
   let arguments = (ins Picceler_ImageType:$input, I64:$value);
@@ -144,15 +155,5 @@ def Picceler_ReadNumberOp : Op<PiccelerDialect, "read_number", []> {
   let arguments = (ins Picceler_StringType:$prompt);
   let results = (outs F64:$result);
 }
-
-def Picceler_PrintOp : Op<PiccelerDialect, "print", []> {
-  let summary = "Print anything to the console, alike std::format";
-  let arguments = (ins AnyType:$input);
-  let results = (outs);
-
-  // let hasVerifier = 1;
-}
-
-
 
 #endif

--- a/tests/lit/mlir/picceler_ops_to_func_calls_pass.mlir
+++ b/tests/lit/mlir/picceler_ops_to_func_calls_pass.mlir
@@ -68,3 +68,101 @@ func.func @ReadStringAndNumber() {
 // CHECK-NEXT: %[[READ_NUM:.*]] = call @piccelerReadNumber(%[[PROMPT2]]) : (!picceler.string) -> f64
 // CHECK-NEXT: return
 
+// -----
+
+func.func @PrintSimpleString() {
+    %fmt = "picceler.string.const"() <{ value = "Hello, World!" }> : () -> !picceler.string
+    "picceler.print"(%fmt) : (!picceler.string) -> ()
+    return
+}
+
+// CHECK-LABEL: func.func @PrintSimpleString()
+// CHECK-DAG: %[[STR:.*]] = "picceler.string.const"() <{value = "Hello, World!"}>
+// CHECK:     call @piccelerPrintString(%[[STR]])
+// CHECK:     return
+
+// -----
+
+func.func @Print2Parts1ArgString() {
+    %fmt1 = "picceler.string.const"() <{ value = "Hello, {}!" }> : () -> !picceler.string
+    %fmt2 = "picceler.string.const"() <{ value = "World" }> : () -> !picceler.string
+    "picceler.print"(%fmt1, %fmt2) : (!picceler.string, !picceler.string) -> ()
+    return
+}
+
+// CHECK-LABEL: func.func @Print2Parts1ArgString()
+// CHECK-DAG: %[[PART2:.*]] = "picceler.string.const"() <{value = "World"}>
+// CHECK-DAG: %[[PART1:.*]] = "picceler.string.const"() <{value = "Hello, "}>
+// CHECK:      call @piccelerPrintString(%[[PART1]])
+// CHECK-NEXT: call @piccelerPrintString(%[[PART2]])
+// CHECK-NEXT: %[[PART3:.*]] = "picceler.string.const"() <{value = "!"}>
+// CHECK-NEXT: call @piccelerPrintString(%[[PART3]])
+// CHECK-NEXT: return
+
+// -----
+
+func.func @Print2Parts1FloatNewlineTerminated() {
+    %fp64 = arith.constant 3.14159 : f64
+    %fmt1 = "picceler.string.const"() <{ value = "The value of pi is approximately: {}\n" }> : () -> !picceler.string
+    "picceler.print"(%fmt1, %fp64) : (!picceler.string, f64) -> ()
+    return
+}
+
+// CHECK-LABEL: func.func @Print2Parts1FloatNewlineTerminated()
+// CHECK-DAG: %[[FP:.*]] = arith.constant 3.141590e+00 : f64
+// CHECK-DAG: %[[PART1:.*]] = "picceler.string.const"() <{value = "The value of pi is approximately: "}>
+// CHECK:      call @piccelerPrintString(%[[PART1]])
+// CHECK-NEXT: call @piccelerPrintFloat64(%[[FP]])
+// CHECK-NEXT: %[[NL:.*]] = "picceler.string.const"() <{value = "\0A"}>
+// CHECK-NEXT: call @piccelerPrintString(%[[NL]])
+// CHECK-NEXT: return
+
+// -----
+
+func.func @PrintAdjacentPlaceholders() {
+    %arg1 = "picceler.string.const"() <{ value = "Foo" }> : () -> !picceler.string
+    %arg2 = "picceler.string.const"() <{ value = "Bar" }> : () -> !picceler.string
+    %fmt = "picceler.string.const"() <{ value = "{}{}\n" }> : () -> !picceler.string
+    "picceler.print"(%fmt, %arg1, %arg2) : (!picceler.string, !picceler.string, !picceler.string) -> ()
+    return
+}
+
+// CHECK-LABEL: func.func @PrintAdjacentPlaceholders()
+// CHECK-DAG: %[[ARG1:.*]] = "picceler.string.const"() <{value = "Foo"}>
+// CHECK-DAG: %[[ARG2:.*]] = "picceler.string.const"() <{value = "Bar"}>
+// CHECK:      call @piccelerPrintString(%[[ARG1]])
+// CHECK-NEXT: call @piccelerPrintString(%[[ARG2]])
+// CHECK:      call @piccelerPrintString
+// CHECK:      return
+
+// -----
+
+func.func @PrintAdjacentNoNewline() {
+    %arg1 = "picceler.string.const"() <{ value = "A" }> : () -> !picceler.string
+    %arg2 = "picceler.string.const"() <{ value = "B" }> : () -> !picceler.string
+    %fmt = "picceler.string.const"() <{ value = "{}{}" }> : () -> !picceler.string
+    "picceler.print"(%fmt, %arg1, %arg2) : (!picceler.string, !picceler.string, !picceler.string) -> ()
+    return
+}
+
+// CHECK-LABEL: func.func @PrintAdjacentNoNewline()
+// CHECK-DAG: %[[ARG1:.*]] = "picceler.string.const"() <{value = "A"}>
+// CHECK-DAG: %[[ARG2:.*]] = "picceler.string.const"() <{value = "B"}>
+// CHECK:      call @piccelerPrintString(%[[ARG1]])
+// CHECK-NEXT: call @piccelerPrintString(%[[ARG2]])
+// CHECK-NEXT: return
+
+// -----
+
+func.func @PrintLeadingPlaceholder(%arg0: f64) {
+    %fmt = "picceler.string.const"() <{ value = "{} is the output\n" }> : () -> !picceler.string
+    "picceler.print"(%fmt, %arg0) : (!picceler.string, f64) -> ()
+    return
+}
+
+// CHECK-LABEL: func.func @PrintLeadingPlaceholder(
+// CHECK-SAME:                                     %[[ARG0:.*]]: f64)
+// CHECK:      call @piccelerPrintFloat64(%[[ARG0]])
+// CHECK-NEXT: %[[SUFFIX:.*]] = "picceler.string.const"() <{value = " is the output\0A"}>
+// CHECK-NEXT: call @piccelerPrintString(%[[SUFFIX]])
+// CHECK-NEXT: return


### PR DESCRIPTION
This PR is quite big and introduces 2 big additions:

1. Location information (line, column) to AST and MLIR, previously, this information was stored in the Lexer's token and also accessed by the parser but never forwarded to AST and MLIR, as such, I've added this, perhaps there are still places where the information location is mishandled but it is a good start.

2. The print functionality, which adds a new op `print` to the dialect which takes a `fmt` string (must be compile time constant) and a variadic number of arguments, we lower this to multiple calls of `piccelerPrint<DataType>`. Added tests for this which should explain what the rewriter does perfectly.