### PR TITLE
Add verifiers, folders and canonicalization patterns for most ops

### DIFF
--- a/examples/brightness.pic
+++ b/examples/brightness.pic
@@ -1,4 +1,38 @@
-img = load_image("~/Pictures/cat.png")
-show_image(img)
-brighter_img = brightness(img, 100)
-show_image(brighter_img)
+def main()
+{
+    img = load_image("~/Pictures/cat.png")
+    show_image(img)
+
+    brightness_func_A(img)
+    brightness_func_B(img)
+    brightness_func_C(img)
+    brightness_func_D(img)
+}
+
+def brightness_func_A(img : image)
+{
+    a = brightness(img, 10)
+    b = brightness(a, 20)
+    
+    show_image(b)
+}
+
+def brightness_func_B(img : image)
+{
+    a = brightness(img, 10)
+    b = brightness(a, -10)
+
+    show_image(b)
+}
+
+def brightness_func_C(img : image)
+{
+    a = brightness(img, 0)
+
+    show_image(a)
+}
+
+def brightness_func_D(img : image)
+{
+    a = brightness(img, 10)
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,6 +44,10 @@ add_library(PiccelerOps STATIC
     ops/brightness.cpp
     ops/invert.cpp
     ops/sharpen.cpp
+    ops/box_blur.cpp
+    ops/gaussian_blur.cpp
+    ops/edge_detect.cpp
+    ops/emboss.cpp
 )
 
 target_link_libraries(PiccelerOps PUBLIC

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -48,6 +48,7 @@ add_library(PiccelerOps STATIC
     ops/gaussian_blur.cpp
     ops/edge_detect.cpp
     ops/emboss.cpp
+    ops/rotate.cpp
 )
 
 target_link_libraries(PiccelerOps PUBLIC

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -41,6 +41,7 @@ add_library(PiccelerOps STATIC
     ops/blend.cpp
     ops/diff.cpp
     ops/print.cpp
+    ops/brightness.cpp
 )
 
 target_link_libraries(PiccelerOps PUBLIC

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,6 +42,8 @@ add_library(PiccelerOps STATIC
     ops/diff.cpp
     ops/print.cpp
     ops/brightness.cpp
+    ops/invert.cpp
+    ops/sharpen.cpp
 )
 
 target_link_libraries(PiccelerOps PUBLIC

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,6 +49,7 @@ add_library(PiccelerOps STATIC
     ops/edge_detect.cpp
     ops/emboss.cpp
     ops/rotate.cpp
+    ops/crop.cpp
 )
 
 target_link_libraries(PiccelerOps PUBLIC

--- a/src/ops/blend.cpp
+++ b/src/ops/blend.cpp
@@ -2,9 +2,13 @@
 #include "ops.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/PatternMatch.h"
 
 namespace picceler {
 
+/**
+ * @brief Verifies the BlendOp to ensure that the weight is a constant in the range [0.0, 1.0].
+ */
 mlir::LogicalResult BlendOp::verify() {
   auto weightValue = getWeight();
   auto constWeight = weightValue.getDefiningOp<mlir::arith::ConstantFloatOp>();
@@ -18,6 +22,57 @@ mlir::LogicalResult BlendOp::verify() {
   }
 
   return mlir::success();
+}
+
+/**
+ * @brief Canonicalization pattern for the BlendOp that replaces blend(img, img, weight) with img if both input images
+ * are the same.
+ */
+struct SameOperandPattern : public mlir::OpRewritePattern<BlendOp> {
+  using mlir::OpRewritePattern<BlendOp>::OpRewritePattern;
+  mlir::LogicalResult matchAndRewrite(BlendOp op, mlir::PatternRewriter &rewriter) const override {
+    auto input1 = op.getInput1();
+    auto input2 = op.getInput2();
+
+    if (input1 == input2) {
+      rewriter.replaceOp(op, input1);
+      return mlir::success();
+    }
+
+    return mlir::failure();
+  }
+};
+
+/**
+ * @brief Registers canonicalization patterns for the BlendOp.
+ * Adds the SameOperandPattern to the provided set of rewrite patterns.
+ * which performs blend(img, img, weight) -> img if both input images are the same
+ *
+ * @param results The set of rewrite patterns to which the canonicalization patterns will be added.
+ * @param context The MLIR context in which the patterns are registered.
+ */
+void BlendOp::getCanonicalizationPatterns(mlir::RewritePatternSet &results, mlir::MLIRContext *context) {
+  results.add<SameOperandPattern>(context);
+}
+
+/**
+ * @brief Folds the BlendOp if the weight is a constant equal to 0.0 or 1.0.
+ * In these cases, the BlendOp can be replaced with one of its input images, as blending with a weight of 0.0 or 1.0
+ * results in one of the input images.
+ *
+ * @param adaptor The FoldAdaptor providing access to the operands and attributes of the BlendOp.
+ * @return mlir::OpFoldResult The folded result, which is one of the input images if the weight is 0.0 or 1.0, or an
+ * empty result if no folding is possible.
+ */
+mlir::OpFoldResult BlendOp::fold(FoldAdaptor adaptor) {
+  if (auto weightAttr = llvm::dyn_cast_or_null<mlir::FloatAttr>(adaptor.getWeight())) {
+    double weight = weightAttr.getValueAsDouble();
+    if (weight == 0.0)
+      return getInput1();
+    if (weight == 1.0)
+      return getInput2();
+  }
+  return {};
 }
 
 mlir::Value BlendOp::transformPixels(mlir::OpBuilder &builder, mlir::Location loc, mlir::Value lhsPixel,

--- a/src/ops/box_blur.cpp
+++ b/src/ops/box_blur.cpp
@@ -1,0 +1,51 @@
+#include "ops.h"
+#include <mlir/IR/Matchers.h>
+#include <mlir/IR/PatternMatch.h>
+
+#include <spdlog/spdlog.h>
+
+namespace picceler {
+
+/**
+ * @brief Verifies the BoxBlurOp to ensure that the input and result types match.
+ * @return mlir::success() if the verification passes, otherwise emits an error and returns mlir::failure().
+ */
+mlir::LogicalResult BoxBlurOp::verify() {
+
+  if (getInput().getType() != getResult().getType()) {
+    return emitOpError("input and result types must match");
+  }
+
+  llvm::APInt radiusVal;
+  if (mlir::matchPattern(getRadius(), mlir::m_ConstantInt(&radiusVal))) {
+    int64_t radius = radiusVal.getSExtValue();
+    if (radius < 0) {
+      return emitOpError("radius must be non-negative, but got ") << radius;
+    }
+  }
+
+  return mlir::success();
+}
+
+/**
+ * @brief Registers canonicalization patterns for the BoxBlurOp.
+ * No canonicalization patterns currently
+ *
+ */
+void BoxBlurOp::getCanonicalizationPatterns(mlir::RewritePatternSet &, mlir::MLIRContext *) {}
+
+/**
+ * @brief Folds away box_blur(img, 0) -> img
+ * @param adaptor The adaptor for the box_blur operation.
+ * @return The folded result if applicable, otherwise an empty OpFoldResult.
+ */
+mlir::OpFoldResult BoxBlurOp::fold(FoldAdaptor adaptor) {
+  if (auto radiusAttr = llvm::dyn_cast_or_null<mlir::IntegerAttr>(adaptor.getRadius())) {
+    if (radiusAttr.getInt() == 0) {
+      return getInput(); // Fold away box_blur(img, 0) -> img
+    }
+  }
+  return {};
+}
+
+} // namespace picceler

--- a/src/ops/brightness.cpp
+++ b/src/ops/brightness.cpp
@@ -1,0 +1,60 @@
+#include "ops.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include <mlir/IR/Matchers.h>
+#include <mlir/IR/PatternMatch.h>
+
+#include <spdlog/spdlog.h>
+
+namespace picceler {
+
+struct ChainedBrightnessPattern : public mlir::OpRewritePattern<BrightnessOp> {
+  using OpRewritePattern<BrightnessOp>::OpRewritePattern;
+
+  mlir::LogicalResult matchAndRewrite(BrightnessOp op, mlir::PatternRewriter &rewriter) const override {
+    auto input = op.getInput();
+
+    auto prevBrightnessOp = input.getDefiningOp<BrightnessOp>();
+    if (!prevBrightnessOp)
+      return mlir::failure();
+
+    if (!prevBrightnessOp.getResult().hasOneUse())
+      return mlir::failure();
+
+    llvm::APInt prevVal, currentVal;
+    if (!mlir::matchPattern(prevBrightnessOp.getValue(), mlir::m_ConstantInt(&prevVal)) ||
+        !mlir::matchPattern(op.getValue(), mlir::m_ConstantInt(&currentVal))) {
+      return mlir::failure();
+    }
+
+    int64_t combinedValue = prevVal.getSExtValue() + currentVal.getSExtValue();
+
+    mlir::Location loc = op.getLoc();
+    auto newConstOp = rewriter.create<mlir::arith::ConstantIntOp>(loc, combinedValue, 64);
+
+    rewriter.replaceOpWithNewOp<BrightnessOp>(op, op.getType(), prevBrightnessOp.getInput(), newConstOp);
+
+    spdlog::info("ChainedBrightnessPattern applied: combined {} and {} into {}", prevVal.getSExtValue(),
+                 currentVal.getSExtValue(), combinedValue);
+
+    return mlir::success();
+  }
+};
+
+void BrightnessOp::getCanonicalizationPatterns(mlir::RewritePatternSet &results, mlir::MLIRContext *context) {
+  results.add<ChainedBrightnessPattern>(context);
+}
+
+mlir::OpFoldResult BrightnessOp::fold(FoldAdaptor adaptor) {
+  auto valueAttr = adaptor.getValue();
+  auto valueIntAttr = mlir::dyn_cast<mlir::IntegerAttr>(valueAttr);
+  if (!valueIntAttr) {
+    return mlir::OpFoldResult();
+  }
+  auto value = valueIntAttr.getInt();
+  if (value == 0) {
+    return getInput();
+  }
+  return mlir::OpFoldResult();
+}
+
+} // namespace picceler

--- a/src/ops/brightness.cpp
+++ b/src/ops/brightness.cpp
@@ -7,6 +7,18 @@
 
 namespace picceler {
 
+mlir::LogicalResult BrightnessOp::verify() {
+  llvm::APInt intVal;
+  if (mlir::matchPattern(getValue(), mlir::m_ConstantInt(&intVal))) {
+    int64_t val = intVal.getSExtValue();
+    if (val < -255 || val > 255) {
+      return emitOpError("brightness value must be in range [-255, 255], but got ") << val;
+    }
+  }
+
+  return mlir::success();
+}
+
 struct ChainedBrightnessPattern : public mlir::OpRewritePattern<BrightnessOp> {
   using OpRewritePattern<BrightnessOp>::OpRewritePattern;
 
@@ -46,7 +58,7 @@ void BrightnessOp::getCanonicalizationPatterns(mlir::RewritePatternSet &results,
 
 mlir::OpFoldResult BrightnessOp::fold(FoldAdaptor adaptor) {
   auto valueAttr = adaptor.getValue();
-  auto valueIntAttr = mlir::dyn_cast<mlir::IntegerAttr>(valueAttr);
+  auto valueIntAttr = mlir::dyn_cast_or_null<mlir::IntegerAttr>(valueAttr);
   if (!valueIntAttr) {
     return mlir::OpFoldResult();
   }

--- a/src/ops/convolution.cpp
+++ b/src/ops/convolution.cpp
@@ -1,7 +1,12 @@
 #include "ops.h"
 #include "types.h"
+#include <mlir/IR/Matchers.h>
+#include <mlir/IR/PatternMatch.h>
+#include <mlir/Dialect/Arith/IR/Arith.h>
 
-#include "mlir/Dialect/Arith/IR/Arith.h"
+#include <spdlog/spdlog.h>
+
+#include <algorithm>
 
 namespace picceler {
 
@@ -19,6 +24,112 @@ llvm::LogicalResult KernelConstOp::verify() {
 
   return mlir::success();
 }
+
+/**
+ * @brief Verifies the ConvolutionOp to ensure that the kernel dimensions are valid.
+ * If the kernel is a KernelType, it checks that the rows and columns are positive.
+ * If the kernel is a MemRefType, it checks that the rank is 2 and that the rows and columns are positive (if they are
+ * not dynamic).
+ *
+ * @return mlir::success() if the verification passes, otherwise emits an error and returns mlir::failure().
+ */
+mlir::LogicalResult ConvolutionOp::verify() {
+  auto kernelOperand = getKernel();
+  if (auto kernelType = mlir::dyn_cast<KernelType>(kernelOperand.getType())) {
+    if (kernelType.getRows() <= 0 || kernelType.getCols() <= 0) {
+      return emitOpError("Kernel dimensions must be positive, got ")
+             << kernelType.getRows() << "x" << kernelType.getCols();
+    }
+  } else if (auto kernelMemRefType = mlir::dyn_cast<mlir::MemRefType>(kernelOperand.getType())) {
+    if (kernelMemRefType.getRank() != 2) {
+      return emitOpError("Kernel operand must have rank 2, got ") << kernelMemRefType.getRank();
+    }
+
+    auto rows = kernelMemRefType.getShape()[0];
+    if (!mlir::ShapedType::isDynamic(rows) && rows <= 0) {
+      return emitOpError("Kernel rows must be positive, got ") << rows;
+    }
+    auto cols = kernelMemRefType.getShape()[1];
+    if (!mlir::ShapedType::isDynamic(cols) && cols <= 0) {
+      return emitOpError("Kernel cols must be positive, got ") << cols;
+    }
+  }
+
+  return mlir::success();
+}
+
+struct IdentityConvolutionPattern : public mlir::OpRewritePattern<ConvolutionOp> {
+  using mlir::OpRewritePattern<ConvolutionOp>::OpRewritePattern;
+
+  mlir::LogicalResult matchAndRewrite(ConvolutionOp op, mlir::PatternRewriter &rewriter) const override {
+    auto kernelOperand = op.getKernel();
+    if (!mlir::isa<KernelType>(kernelOperand.getType())) {
+      return mlir::failure();
+    }
+
+    auto kernelType = mlir::cast<KernelType>(kernelOperand.getType());
+    auto rows = kernelType.getRows();
+    auto cols = kernelType.getCols();
+
+    if (rows != cols || rows % 2 == 0) {
+      return mlir::failure();
+    }
+
+    auto definingOp = kernelOperand.getDefiningOp<KernelConstOp>();
+    if (!definingOp) {
+      return mlir::failure();
+    }
+
+    auto valuesAttr = definingOp.getValues();
+    auto floatValues = valuesAttr.getValues<llvm::APFloat>();
+
+    if (static_cast<int64_t>(floatValues.size()) != rows * cols) {
+      return mlir::failure();
+    }
+
+    int64_t centerR = rows / 2;
+    int64_t centerC = cols / 2;
+
+    int64_t nonZeroCount = 0;
+
+    for (int64_t i = 0; i < rows; ++i) {
+      for (int64_t j = 0; j < cols; ++j) {
+        double value = floatValues[i * cols + j].convertToDouble();
+
+        if (value != 0.0) {
+          ++nonZeroCount;
+        }
+      }
+    }
+
+    if (nonZeroCount != 1) {
+      spdlog::debug("IdentityConvolutionPattern: Kernel has {} non-zero values, expected 1", nonZeroCount);
+      return mlir::failure();
+    }
+
+    if (floatValues[centerR * cols + centerC].convertToDouble() != 1.0) {
+      spdlog::debug("IdentityConvolutionPattern: Center value is not 1.0");
+      return mlir::failure();
+    }
+
+    rewriter.replaceOp(op, op.getInput());
+    return mlir::success();
+  }
+};
+
+/**
+ * @brief Registers canonicalization patterns for the ConvolutionOp.
+ * Adds the IdentityConvolutionPattern to the provided set of rewrite patterns.
+ * which performs convolution(img, kernel) -> img if the kernel is an identity kernel.
+ *
+ * @param results The set of rewrite patterns to which the canonicalization patterns will be added.
+ * @param context The MLIR context in which the patterns are being registered.
+ */
+void ConvolutionOp::getCanonicalizationPatterns(mlir::RewritePatternSet &results, mlir::MLIRContext *context) {
+  results.add<IdentityConvolutionPattern>(context);
+}
+
+mlir::OpFoldResult ConvolutionOp::fold(FoldAdaptor adaptor) { return {}; }
 
 Result<std::pair<mlir::Value, mlir::Value>> getKernelNeighborhoodSize(mlir::OpBuilder &builder, mlir::Location loc,
                                                                       mlir::Value kernelOperand) {

--- a/src/ops/crop.cpp
+++ b/src/ops/crop.cpp
@@ -1,0 +1,102 @@
+#include "ops.h"
+#include <mlir/IR/Matchers.h>
+#include <mlir/IR/PatternMatch.h>
+#include <mlir/Dialect/Arith/IR/Arith.h>
+
+#include <spdlog/spdlog.h>
+
+namespace picceler {
+
+/**
+ * @brief Verifies the CropOp to ensure that the x and y coordinates are non-negative and that the width and height are
+ * strictly positive if they are constant integers.
+ */
+mlir::LogicalResult CropOp::verify() {
+  llvm::APInt xVal;
+  llvm::APInt yVal;
+  llvm::APInt wVal;
+  llvm::APInt hVal;
+
+  if (mlir::matchPattern(getX(), mlir::m_ConstantInt(&xVal)) && xVal.getSExtValue() < 0)
+    return emitOpError("x coordinate must be non-negative");
+
+  if (mlir::matchPattern(getY(), mlir::m_ConstantInt(&yVal)) && yVal.getSExtValue() < 0)
+    return emitOpError("y coordinate must be non-negative");
+
+  if (mlir::matchPattern(getWidth(), mlir::m_ConstantInt(&wVal)) && wVal.getSExtValue() <= 0)
+    return emitOpError("crop width must be strictly positive");
+
+  if (mlir::matchPattern(getHeight(), mlir::m_ConstantInt(&hVal)) && hVal.getSExtValue() <= 0)
+    return emitOpError("crop height must be strictly positive");
+
+  return mlir::success();
+}
+
+/**
+ * @brief Canonicalization pattern for the CropOp that combines nested crop operations into a single crop operation.
+ * only applicable when both crop operations have constant integer coordinates and dimensions.
+ */
+struct CombineNestedCrops : public mlir::OpRewritePattern<CropOp> {
+  using OpRewritePattern<CropOp>::OpRewritePattern;
+
+  mlir::LogicalResult matchAndRewrite(CropOp outerCrop, mlir::PatternRewriter &rewriter) const override {
+    auto innerCrop = outerCrop.getInput().getDefiningOp<CropOp>();
+    if (!innerCrop)
+      return mlir::failure();
+
+    llvm::APInt x1, y1, w1, h1;
+    llvm::APInt x2, y2, w2, h2;
+
+    if (!mlir::matchPattern(innerCrop.getX(), mlir::m_ConstantInt(&x1)) ||
+        !mlir::matchPattern(innerCrop.getY(), mlir::m_ConstantInt(&y1)) ||
+        !mlir::matchPattern(innerCrop.getWidth(), mlir::m_ConstantInt(&w1)) ||
+        !mlir::matchPattern(innerCrop.getHeight(), mlir::m_ConstantInt(&h1)))
+      return mlir::failure();
+
+    if (!mlir::matchPattern(outerCrop.getX(), mlir::m_ConstantInt(&x2)) ||
+        !mlir::matchPattern(outerCrop.getY(), mlir::m_ConstantInt(&y2)) ||
+        !mlir::matchPattern(outerCrop.getWidth(), mlir::m_ConstantInt(&w2)) ||
+        !mlir::matchPattern(outerCrop.getHeight(), mlir::m_ConstantInt(&h2)))
+      return mlir::failure();
+
+    int64_t x1Val = x1.getSExtValue();
+    int64_t y1Val = y1.getSExtValue();
+    int64_t w1Val = w1.getSExtValue();
+    int64_t h1Val = h1.getSExtValue();
+
+    int64_t x2Val = x2.getSExtValue();
+    int64_t y2Val = y2.getSExtValue();
+    int64_t w2Val = w2.getSExtValue();
+    int64_t h2Val = h2.getSExtValue();
+
+    int64_t fusedX = x1Val + x2Val;
+    int64_t fusedY = y1Val + y2Val;
+    int64_t fusedW = std::min(w2Val, std::max<int64_t>(0, w1Val - x2Val));
+    int64_t fusedH = std::min(h2Val, std::max<int64_t>(0, h1Val - y2Val));
+
+    mlir::Location loc = outerCrop.getLoc();
+    auto newX = rewriter.create<mlir::arith::ConstantIntOp>(loc, fusedX, 64);
+    auto newY = rewriter.create<mlir::arith::ConstantIntOp>(loc, fusedY, 64);
+    auto newW = rewriter.create<mlir::arith::ConstantIntOp>(loc, fusedW, 64);
+    auto newH = rewriter.create<mlir::arith::ConstantIntOp>(loc, fusedH, 64);
+
+    rewriter.replaceOpWithNewOp<CropOp>(outerCrop, outerCrop.getType(), innerCrop.getInput(), newX, newY, newW, newH);
+    return mlir::success();
+  }
+};
+
+/**
+ * @brief Registers canonicalization patterns for the CropOp.
+ * Adds the CombineNestedCrops pattern to the provided set of rewrite patterns.
+ * which combines nested crop operations into a single crop operation.
+ *
+ * @param results The set of rewrite patterns to which the canonicalization patterns will be added.
+ * @param context The MLIR context in which the patterns are registered.
+ */
+void CropOp::getCanonicalizationPatterns(mlir::RewritePatternSet &results, mlir::MLIRContext *context) {
+  results.add<CombineNestedCrops>(context);
+}
+
+mlir::OpFoldResult CropOp::fold(FoldAdaptor) { return {}; }
+
+} // namespace picceler

--- a/src/ops/diff.cpp
+++ b/src/ops/diff.cpp
@@ -2,8 +2,41 @@
 #include "channels.h"
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/PatternMatch.h"
 
 namespace picceler {
+
+/**
+ * @brief Verifies the DiffOp to ensure that the input images have the same type and that the result image type matches
+ * the input image types.
+ *
+ * @return mlir::success() if the verification passes, otherwise emits an error and returns mlir::failure().
+ */
+mlir::LogicalResult DiffOp::verify() {
+  auto input1 = getInput1();
+  auto input2 = getInput2();
+
+  if (input1.getType() != input2.getType()) {
+    return emitOpError("Input images must have the same type, got ") << input1.getType() << " and " << input2.getType();
+  }
+
+  if (input1.getType() != getResult().getType()) {
+    return emitOpError("Result image type must match input image types, got ")
+           << getResult().getType() << " and " << input1.getType();
+  }
+
+  return mlir::success();
+}
+
+/**
+ * @brief Registers canonicalization patterns for the DiffOp
+ *
+ * @param results The set of rewrite patterns to which the canonicalization patterns will be added.
+ * @param context The MLIR context in which the patterns are registered.
+ */
+void DiffOp::getCanonicalizationPatterns(mlir::RewritePatternSet &, mlir::MLIRContext *) {}
+
+mlir::OpFoldResult DiffOp::fold(FoldAdaptor) { return {}; }
 
 mlir::Value DiffOp::transformPixels(mlir::OpBuilder &builder, mlir::Location loc, mlir::Value lhsPixel,
                                     mlir::Value rhsPixel, Channel ch) {

--- a/src/ops/dilate.cpp
+++ b/src/ops/dilate.cpp
@@ -36,6 +36,18 @@ mlir::LogicalResult DilateOp::verify() {
   return mlir::success();
 }
 
+void DilateOp::getCanonicalizationPatterns(mlir::RewritePatternSet &results, mlir::MLIRContext *context) {}
+
+mlir::OpFoldResult DilateOp::fold(FoldAdaptor adaptor) {
+  if (auto radiusAttr = mlir::dyn_cast_or_null<mlir::IntegerAttr>(adaptor.getRadius())) {
+    auto radiusValue = radiusAttr.getInt();
+    if (radiusValue == 0) {
+      return getInput();
+    }
+  }
+  return {};
+}
+
 mlir::Value DilateOp::initializeAccumulator(mlir::OpBuilder &builder, mlir::Location loc) {
   return createFloatConstant(builder, loc, -std::numeric_limits<double>::infinity());
 }

--- a/src/ops/edge_detect.cpp
+++ b/src/ops/edge_detect.cpp
@@ -1,0 +1,59 @@
+#include "ops.h"
+#include <mlir/IR/Matchers.h>
+#include <mlir/IR/PatternMatch.h>
+
+#include <spdlog/spdlog.h>
+
+namespace picceler {
+
+/**
+ * @brief Verifies the EdgeDetectOp to ensure that the input and result types match.
+ *
+ * @return mlir::success() if the verification passes, otherwise emits an error and returns mlir::failure().
+ */
+mlir::LogicalResult EdgeDetectOp::verify() {
+  if (getInput().getType() != getResult().getType()) {
+    return emitOpError("input and result types must match");
+  }
+
+  return mlir::success();
+}
+
+struct RemoveInvertPattern : public mlir::OpRewritePattern<EdgeDetectOp> {
+  using mlir::OpRewritePattern<EdgeDetectOp>::OpRewritePattern;
+  mlir::LogicalResult matchAndRewrite(EdgeDetectOp op, mlir::PatternRewriter &rewriter) const override {
+    auto input = op.getInput();
+    auto invertOp = input.getDefiningOp<InvertOp>();
+    if (!invertOp) {
+      return mlir::failure();
+    }
+
+    rewriter.replaceOpWithNewOp<EdgeDetectOp>(op, op.getType(), invertOp.getInput());
+
+    spdlog::debug("RemoveInvertPattern applied: edge_detect(invert(img)) -> edge_detect(img)");
+
+    return mlir::success();
+  }
+};
+
+/**
+ * @brief Registers canonicalization patterns for the EdgeDetectOp.
+ * Adds a pattern to remove an invert operation that is immediately followed by an edge_detect operation.
+ * edge_detect(invert(img)) -> edge_detect(img)
+ *
+ * @param results The set of rewrite patterns to populate.
+ * @param context The MLIR context in which the patterns are registered.
+ */
+void EdgeDetectOp::getCanonicalizationPatterns(mlir::RewritePatternSet &results, mlir::MLIRContext *context) {
+  results.add<RemoveInvertPattern>(context);
+}
+
+/**
+ * @brief Folder for the EdgeDetectOp.
+ * Currently, there are no folding rules implemented for this operation.
+ *
+ * @return returnsan empty OpFoldResult.
+ */
+mlir::OpFoldResult EdgeDetectOp::fold(FoldAdaptor) { return {}; }
+
+} // namespace picceler

--- a/src/ops/emboss.cpp
+++ b/src/ops/emboss.cpp
@@ -1,0 +1,37 @@
+#include "ops.h"
+#include <mlir/IR/Matchers.h>
+#include <mlir/IR/PatternMatch.h>
+
+#include <spdlog/spdlog.h>
+
+namespace picceler {
+
+/**
+ * @brief Verifies the EmbossOp to ensure that the input and result types match.
+ *
+ * @return mlir::success() if the verification passes, otherwise emits an error and returns mlir::failure().
+ */
+mlir::LogicalResult EmbossOp::verify() {
+  if (getInput().getType() != getResult().getType()) {
+    return emitOpError("input and result types must match");
+  }
+
+  return mlir::success();
+}
+
+/**
+ * @brief Registers canonicalization patterns for the EmbossOp.
+ * No canonicalization patterns currently
+ *
+ */
+void EmbossOp::getCanonicalizationPatterns(mlir::RewritePatternSet &, mlir::MLIRContext *) {}
+
+/**
+ * @brief Folder for the EmbossOp.
+ * Currently, there are no folding rules implemented for this operation.
+ *
+ * @return returns an empty OpFoldResult.
+ */
+mlir::OpFoldResult EmbossOp::fold(FoldAdaptor) { return {}; }
+
+} // namespace picceler

--- a/src/ops/erode.cpp
+++ b/src/ops/erode.cpp
@@ -7,6 +7,9 @@
 
 namespace picceler {
 
+/**
+ * @brief Verifies the ErodeOp to ensure that the radius is a non-negative integer if it's a constant.
+ */
 mlir::LogicalResult ErodeOp::verify() {
 
   auto radius = getRadius();
@@ -33,6 +36,30 @@ mlir::LogicalResult ErodeOp::verify() {
   }
 
   return mlir::success();
+}
+
+/**
+ * @brief Registers canonicalization patterns for the ErodeOp.
+ * No canonicalization patterns
+ */
+void ErodeOp::getCanonicalizationPatterns(mlir::RewritePatternSet &, mlir::MLIRContext *) {}
+
+/**
+ * @brief Folds the ErodeOp if the radius is a constant integer equal to 0.
+ * In this case, the ErodeOp can be replaced with its input image, as eroding with a radius of 0 has no effect.
+ *
+ * @param adaptor The FoldAdaptor providing access to the operands and attributes of the ErodeOp.
+ * @return mlir::OpFoldResult The folded result, which is the input image if the radius is 0, or an empty result if no
+ * folding is possible.
+ */
+mlir::OpFoldResult ErodeOp::fold(FoldAdaptor adaptor) {
+  if (auto radiusAttr = mlir::dyn_cast_or_null<mlir::IntegerAttr>(adaptor.getRadius())) {
+    auto radiusValue = radiusAttr.getInt();
+    if (radiusValue == 0) {
+      return getInput();
+    }
+  }
+  return {};
 }
 
 mlir::Value ErodeOp::initializeAccumulator(mlir::OpBuilder &builder, mlir::Location loc) {

--- a/src/ops/gaussian_blur.cpp
+++ b/src/ops/gaussian_blur.cpp
@@ -1,0 +1,50 @@
+#include "ops.h"
+#include <mlir/IR/Matchers.h>
+#include <mlir/IR/PatternMatch.h>
+
+#include <spdlog/spdlog.h>
+
+namespace picceler {
+
+/**
+ * @brief Verifies the GaussianBlurOp to ensure that the input and result types match.
+ * but also checks that the radius is non-negative if it's a constant integer.
+ * @return mlir::success() if the verification passes, otherwise emits an error and returns mlir::failure().
+ */
+mlir::LogicalResult GaussianBlurOp::verify() {
+  if (getInput().getType() != getResult().getType()) {
+    return emitOpError("input and result types must match");
+  }
+
+  llvm::APInt radiusVal;
+  if (mlir::matchPattern(getRadius(), mlir::m_ConstantInt(&radiusVal))) {
+    int64_t radius = radiusVal.getSExtValue();
+    if (radius < 0) {
+      return emitOpError("radius must be non-negative, but got ") << radius;
+    }
+  }
+
+  return mlir::success();
+}
+
+/**
+ * @brief Registers canonicalization patterns for the GaussianBlurOp.
+ * No canonicalization patterns currently
+ */
+void GaussianBlurOp::getCanonicalizationPatterns(mlir::RewritePatternSet &, mlir::MLIRContext *) {}
+
+/**
+ * @brief Folds away gaussian_blur(img, 0) -> img
+ * @param adaptor The adaptor for the gaussian_blur operation.
+ * @return The folded result if applicable, otherwise an empty OpFoldResult.
+ */
+mlir::OpFoldResult GaussianBlurOp::fold(FoldAdaptor adaptor) {
+  if (auto radiusAttr = llvm::dyn_cast_or_null<mlir::IntegerAttr>(adaptor.getRadius())) {
+    if (radiusAttr.getInt() == 0) {
+      return getInput(); // Fold away gaussian_blur(img, 0) -> img
+    }
+  }
+  return {};
+}
+
+} // namespace picceler

--- a/src/ops/invert.cpp
+++ b/src/ops/invert.cpp
@@ -1,0 +1,41 @@
+#include "ops.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include <mlir/IR/Matchers.h>
+#include <mlir/IR/PatternMatch.h>
+
+#include <spdlog/spdlog.h>
+
+namespace picceler {
+
+mlir::LogicalResult InvertOp::verify() {
+
+  if (getInput().getType() != getResult().getType()) {
+    return emitOpError("input and result types must match");
+  }
+
+  return mlir::success();
+}
+
+struct ChainedInvertPattern : public mlir::OpRewritePattern<InvertOp> {
+  using OpRewritePattern<InvertOp>::OpRewritePattern;
+
+  mlir::LogicalResult matchAndRewrite(InvertOp op, mlir::PatternRewriter &rewriter) const override {
+    auto input = op.getInput();
+
+    if (auto definingOp = input.getDefiningOp<InvertOp>()) {
+      auto newInput = definingOp.getInput();
+      rewriter.replaceOp(op, newInput);
+      return mlir::success();
+    }
+
+    return mlir::success();
+  }
+};
+
+void InvertOp::getCanonicalizationPatterns(mlir::RewritePatternSet &results, mlir::MLIRContext *context) {
+  results.add<ChainedInvertPattern>(context);
+}
+
+mlir::OpFoldResult InvertOp::fold(FoldAdaptor adaptor) { return mlir::OpFoldResult(); }
+
+} // namespace picceler

--- a/src/ops/rotate.cpp
+++ b/src/ops/rotate.cpp
@@ -1,0 +1,79 @@
+#include "ops.h"
+#include <mlir/IR/Matchers.h>
+#include <mlir/IR/PatternMatch.h>
+#include <mlir/Dialect/Arith/IR/Arith.h>
+
+#include <spdlog/spdlog.h>
+
+namespace picceler {
+
+/**
+ * @brief Verifies the RotateOp to ensure that the angle is a multiple of 90 degrees if it's a constant integer.
+ *
+ * @return mlir::success() if the verification passes, otherwise emits an error and returns mlir::failure().
+ */
+mlir::LogicalResult RotateOp::verify() {
+  llvm::APInt angleVal;
+  if (mlir::matchPattern(getAngle(), mlir::m_ConstantInt(&angleVal))) {
+    int64_t angle = angleVal.getSExtValue();
+    if (angle % 90 != 0) {
+      return emitOpError("angle must be a multiple of 90, got ") << angle;
+    }
+  }
+
+  return mlir::success();
+}
+
+struct ChainRotatePattern : public mlir::OpRewritePattern<RotateOp> {
+  using mlir::OpRewritePattern<RotateOp>::OpRewritePattern;
+  mlir::LogicalResult matchAndRewrite(RotateOp op, mlir::PatternRewriter &rewriter) const override {
+    auto input = op.getInput();
+    auto prevRotateOp = input.getDefiningOp<RotateOp>();
+    if (!prevRotateOp) {
+      return mlir::failure();
+    }
+
+    llvm::APInt constantAnglePrev;
+    llvm::APInt constantAngleCurrent;
+    if (mlir::matchPattern(prevRotateOp.getAngle(), mlir::m_ConstantInt(&constantAnglePrev)) &&
+        mlir::matchPattern(op.getAngle(), mlir::m_ConstantInt(&constantAngleCurrent))) {
+      auto combined = constantAnglePrev.getSExtValue() + constantAngleCurrent.getSExtValue();
+      auto normalized = ((combined % 360) + 360) % 360;
+      auto newConstantAngle = rewriter.create<mlir::arith::ConstantIntOp>(op.getLoc(), normalized, 64);
+      rewriter.replaceOpWithNewOp<RotateOp>(op, op.getType(), prevRotateOp.getInput(), newConstantAngle);
+    } else {
+      auto newAngle = rewriter.create<mlir::arith::AddIOp>(op.getLoc(), prevRotateOp.getAngle(), op.getAngle());
+      rewriter.replaceOpWithNewOp<RotateOp>(op, op.getType(), prevRotateOp.getInput(), newAngle);
+    }
+
+    spdlog::debug("ChainRotatePattern applied: rotate(rotate(img, a1), a2) -> rotate(img, a1 + a2)");
+
+    return mlir::success();
+  }
+};
+
+/**
+ * @brief Registers canonicalization patterns for the RotateOp.
+ * Adds the ChainRotatePattern to the provided set of rewrite patterns.
+ * which performs rotate(rotate(img, a1), a2) -> rotate(img, a1 + a2)
+ * either at compile time if both angles are constants, or at runtime if one or both angles are dynamic.
+ *
+ * @param results The set of rewrite patterns to which the canonicalization patterns will be added.
+ * @param context The MLIR context in which the patterns are registered.
+ */
+void RotateOp::getCanonicalizationPatterns(mlir::RewritePatternSet &results, mlir::MLIRContext *context) {
+  results.add<ChainRotatePattern>(context);
+}
+
+mlir::OpFoldResult RotateOp::fold(FoldAdaptor adaptor) {
+  if (auto angleAttr = llvm::dyn_cast_or_null<mlir::IntegerAttr>(adaptor.getAngle())) {
+    int64_t angle = angleAttr.getInt();
+    int64_t normalizedAngle = ((angle % 360) + 360) % 360;
+    if (normalizedAngle == 0) {
+      return getInput(); // Fold away rotate(img, 0/360/720/-360) -> img
+    }
+  }
+  return {};
+}
+
+} // namespace picceler

--- a/src/ops/sharpen.cpp
+++ b/src/ops/sharpen.cpp
@@ -1,0 +1,33 @@
+#include "ops.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include <mlir/IR/Matchers.h>
+#include <mlir/IR/PatternMatch.h>
+
+#include <spdlog/spdlog.h>
+
+namespace picceler {
+
+mlir::LogicalResult SharpenOp::verify() {
+
+  if (getInput().getType() != getResult().getType()) {
+    return emitOpError("input and result types must match");
+  }
+
+  return mlir::success();
+}
+
+void SharpenOp::getCanonicalizationPatterns(mlir::RewritePatternSet &results, mlir::MLIRContext *context) {
+  // no canonicalization patterns for sharpen yet
+  // to be implemented in the future when sharpen takes strength and is fixed 3x3 sliding window
+}
+
+mlir::OpFoldResult SharpenOp::fold(FoldAdaptor adaptor) {
+  if (auto valueAttr = llvm::dyn_cast_or_null<mlir::IntegerAttr>(adaptor.getValue())) {
+    if (valueAttr.getInt() == 0) {
+      return getInput(); // Fold away sharpen(img, 0) -> img
+    }
+  }
+  return {};
+}
+
+} // namespace picceler

--- a/src/ops/sharpen.cpp
+++ b/src/ops/sharpen.cpp
@@ -1,11 +1,13 @@
 #include "ops.h"
-#include "mlir/Dialect/Arith/IR/Arith.h"
 #include <mlir/IR/Matchers.h>
 #include <mlir/IR/PatternMatch.h>
 
 #include <spdlog/spdlog.h>
 
 namespace picceler {
+
+// TODO: Refactor SharpenOp to use strength as input instead of radius
+//  and make it a fixed 3x3 kernel.
 
 mlir::LogicalResult SharpenOp::verify() {
 

--- a/src/picceler_kernel_to_memref_pass.cpp
+++ b/src/picceler_kernel_to_memref_pass.cpp
@@ -2,30 +2,37 @@
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Func/Transforms/FuncConversions.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
-#include "mlir/Transforms/DialectConversion.h"
-#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
 
 #include "ops.h"
 #include "types.h"
 
 namespace picceler {
 
-struct KernelToMemref : mlir::OpRewritePattern<KernelConstOp> {
-  using OpRewritePattern<KernelConstOp>::OpRewritePattern;
+struct KernelToMemref : public mlir::OpConversionPattern<KernelConstOp> {
+  using OpConversionPattern<KernelConstOp>::OpConversionPattern;
 
-  mlir::LogicalResult matchAndRewrite(KernelConstOp op, mlir::PatternRewriter &rewriter) const override {
+  mlir::LogicalResult matchAndRewrite(KernelConstOp op, OpAdaptor adaptor,
+                                      mlir::ConversionPatternRewriter &rewriter) const override {
     mlir::Location loc = op.getLoc();
     auto f64Type = rewriter.getF64Type();
 
-    auto kernelType = mlir::cast<KernelType>(op.getResult().getType());
-    int64_t rows = kernelType.getRows();
+    auto kernelType = mlir::dyn_cast<KernelType>(op.getResult().getType());
+    if (!kernelType)
+      return mlir::failure();
+
     int64_t cols = kernelType.getCols();
 
-    auto memrefType = mlir::MemRefType::get({rows, cols}, f64Type);
+    // Safe conversion check
+    auto convertedType = getTypeConverter()->convertType(kernelType);
+    if (!convertedType)
+      return mlir::failure();
 
+    auto memrefType = mlir::cast<mlir::MemRefType>(convertedType);
     auto allocaOp = rewriter.create<mlir::memref::AllocaOp>(loc, memrefType);
     mlir::Value kStack = allocaOp.getResult();
 
@@ -34,13 +41,15 @@ struct KernelToMemref : mlir::OpRewritePattern<KernelConstOp> {
       return mlir::failure();
 
     int64_t i = 0;
-    for (double val : kvaluesAttr.getValues<double>()) {
+    for (const llvm::APFloat &val : kvaluesAttr.getValues<llvm::APFloat>()) {
       int64_t idx = i++;
       int64_t r = idx / cols;
       int64_t c = idx % cols;
+
       auto cRow = rewriter.create<mlir::arith::ConstantIndexOp>(loc, r);
       auto cCol = rewriter.create<mlir::arith::ConstantIndexOp>(loc, c);
-      auto cVal = rewriter.create<mlir::arith::ConstantFloatOp>(loc, f64Type, llvm::APFloat(val));
+      auto cVal = rewriter.create<mlir::arith::ConstantFloatOp>(loc, f64Type, val);
+
       rewriter.create<mlir::memref::StoreOp>(loc, cVal, kStack, mlir::ValueRange{cRow, cCol});
     }
 
@@ -52,16 +61,33 @@ struct KernelToMemref : mlir::OpRewritePattern<KernelConstOp> {
 #define GEN_PASS_DEF_PICCELERKERNELTOMEMREF
 #include "piccelerPasses.h.inc"
 
-/**
- * @brief A pass that converts KernelConstOp operations, which represent constant convolution kernels, into MemRef
- * operations that allocate memory for the kernel and store the constant values into it.
- */
 struct PiccelerKernelToMemrefPass : public impl::PiccelerKernelToMemrefBase<PiccelerKernelToMemrefPass> {
   void runOnOperation() override {
-    mlir::RewritePatternSet patterns(&getContext());
-    patterns.add<KernelToMemref>(&getContext());
+    mlir::MLIRContext &context = getContext();
 
-    if (mlir::failed(mlir::applyPatternsGreedily(getOperation(), std::move(patterns)))) {
+    mlir::TypeConverter typeConverter;
+    typeConverter.addConversion([](mlir::Type type) { return type; });
+    typeConverter.addConversion([](KernelType kernelType) -> mlir::Type {
+      return mlir::MemRefType::get({kernelType.getRows(), kernelType.getCols()},
+                                   mlir::Float64Type::get(kernelType.getContext()));
+    });
+
+    mlir::RewritePatternSet patterns(&context);
+    patterns.add<KernelToMemref>(typeConverter, &context);
+
+    mlir::populateFunctionOpInterfaceTypeConversionPattern<mlir::func::FuncOp>(patterns, typeConverter);
+    mlir::populateReturnOpTypeConversionPattern(patterns, typeConverter);
+
+    mlir::ConversionTarget target(context);
+    target.addIllegalOp<KernelConstOp>();
+    target.addLegalDialect<mlir::arith::ArithDialect, mlir::memref::MemRefDialect, mlir::func::FuncDialect>();
+
+    target.addDynamicallyLegalOp<mlir::func::FuncOp>(
+        [&](mlir::func::FuncOp op) { return typeConverter.isSignatureLegal(op.getFunctionType()); });
+    target.addDynamicallyLegalOp<mlir::func::ReturnOp>(
+        [&](mlir::func::ReturnOp op) { return typeConverter.isLegal(op.getOperandTypes()); });
+
+    if (mlir::failed(mlir::applyPartialConversion(getOperation(), target, std::move(patterns)))) {
       signalPassFailure();
     }
   }

--- a/tablegen/ops.td
+++ b/tablegen/ops.td
@@ -60,59 +60,73 @@ def Picceler_BrightnessOp : Op<PiccelerDialect, "brightness", [Pure]> {
   let arguments = (ins Picceler_ImageType:$input, I64:$value);
   let results = (outs Picceler_ImageType:$result);
 
+  let hasVerifier = 1;
   let hasFolder = 1;
   let hasCanonicalizer = 1;
 }
 
-def Picceler_InvertOp : Op<PiccelerDialect, "invert", []> {
+def Picceler_InvertOp : Op<PiccelerDialect, "invert", [Pure]> {
   let summary = "Invert the pixels of an image";
   let arguments = (ins Picceler_ImageType:$input);
   let results = (outs Picceler_ImageType:$result);
+
+  let hasVerifier = 1;
+  let hasFolder = 1;
+  let hasCanonicalizer = 1;
 }
 
-def Picceler_SharpenOp : Op<PiccelerDialect, "sharpen", []> {
+def Picceler_SharpenOp : Op<PiccelerDialect, "sharpen", [Pure]> {
   let summary = "Adjust the sharpness of an image";
   let arguments = (ins Picceler_ImageType:$input, I64:$value);
   let results = (outs Picceler_ImageType:$result);
+
+  let hasVerifier = 1;
+  let hasFolder = 1;
+  let hasCanonicalizer = 1;
 }
 
-def Picceler_BoxBlurOp : Op<PiccelerDialect, "box_blur", []> {
+def Picceler_BoxBlurOp : Op<PiccelerDialect, "box_blur", [Pure]> {
   let summary = "Apply a simple box blur";
   let arguments = (ins Picceler_ImageType:$input, I64:$radius);
   let results = (outs Picceler_ImageType:$result);
 }
 
-def Picceler_GaussianBlurOp : Op<PiccelerDialect, "gaussian_blur", []> {
+def Picceler_GaussianBlurOp : Op<PiccelerDialect, "gaussian_blur", [Pure]> {
   let summary = "Apply a gaussian blur (smoother)";
   let arguments = (ins Picceler_ImageType:$input, I64:$radius);
   let results = (outs Picceler_ImageType:$result);
 }
 
-def Picceler_EdgeDetectOp : Op<PiccelerDialect, "edge_detect", []> {
+def Picceler_EdgeDetectOp : Op<PiccelerDialect, "edge_detect", [Pure]> {
   let summary = "Detect edges in the image";
   let arguments = (ins Picceler_ImageType:$input);
   let results = (outs Picceler_ImageType:$result);
 }
 
-def Picceler_EmbossOp : Op<PiccelerDialect, "emboss", []> {
+def Picceler_EmbossOp : Op<PiccelerDialect, "emboss", [Pure]> {
   let summary = "Apply a 3D emboss effect";
   let arguments = (ins Picceler_ImageType:$input);
   let results = (outs Picceler_ImageType:$result);
 }
 
-def Picceler_RotateOp : Op<PiccelerDialect, "rotate", []> {
+def Picceler_RotateOp : Op<PiccelerDialect, "rotate", [Pure]> {
   let summary = "Rotate an image around its center";
   let arguments = (ins Picceler_ImageType:$input, I64:$angle);
   let results = (outs Picceler_ImageType:$result);
 }
 
-def Picceler_ConvolutionOp : Op<PiccelerDialect, "convolution", [NeighbourhoodOpInterface, DeclareOpInterfaceMethods<NeighbourhoodOpInterface, ["initializeAccumulator", "accumulate", "finalizeAccumulator", "getNeighborhoodSize"]>]> {
+def Picceler_ConvolutionOp : Op<PiccelerDialect, "convolution", [Pure,NeighbourhoodOpInterface,
+ DeclareOpInterfaceMethods<NeighbourhoodOpInterface, ["initializeAccumulator", "accumulate", "finalizeAccumulator", "getNeighborhoodSize"]>
+ ]> {
   let summary = "Apply convolution to an image with a kernel";
   let arguments = (ins Picceler_ImageType:$input, AnyTypeOf<[Picceler_KernelType, AnyMemRef]>:$kernel);
   let results = (outs Picceler_ImageType:$result);
 }
 
-def Picceler_ErodeOp : Op<PiccelerDialect, "erode", [NeighbourhoodOpInterface, DeclareOpInterfaceMethods<NeighbourhoodOpInterface, ["initializeAccumulator", "accumulate", "finalizeAccumulator", "getNeighborhoodSize"]>]> {
+def Picceler_ErodeOp : Op<PiccelerDialect, "erode", [Pure, NeighbourhoodOpInterface,
+ DeclareOpInterfaceMethods<NeighbourhoodOpInterface,
+  ["initializeAccumulator", "accumulate", "finalizeAccumulator", "getNeighborhoodSize"]>
+  ]> {
   let summary = "Apply erosion to an image";
   let arguments = (ins Picceler_ImageType:$input, I64:$radius);
   let results = (outs Picceler_ImageType:$result);
@@ -120,7 +134,10 @@ def Picceler_ErodeOp : Op<PiccelerDialect, "erode", [NeighbourhoodOpInterface, D
   let hasVerifier = 1;
 }
 
-def Picceler_DilateOp : Op<PiccelerDialect, "dilate", [NeighbourhoodOpInterface, DeclareOpInterfaceMethods<NeighbourhoodOpInterface, ["initializeAccumulator", "accumulate", "finalizeAccumulator", "getNeighborhoodSize"]>]> {
+def Picceler_DilateOp : Op<PiccelerDialect, "dilate", [Pure, NeighbourhoodOpInterface,
+ DeclareOpInterfaceMethods<NeighbourhoodOpInterface,
+  ["initializeAccumulator", "accumulate", "finalizeAccumulator", "getNeighborhoodSize"]>
+  ]> {
   let summary = "Apply dilation to an image";
   let arguments = (ins Picceler_ImageType:$input, I64:$radius);
   let results = (outs Picceler_ImageType:$result);

--- a/tablegen/ops.td
+++ b/tablegen/ops.td
@@ -9,6 +9,7 @@
 #define PICCELER_OPS_TD
 
 include "mlir/IR/OpBase.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
 include "interfaces.td"
 include "types.td"
 
@@ -54,10 +55,13 @@ def Picceler_PrintOp : Op<PiccelerDialect, "print", []> {
   let hasVerifier = 1;
 }
 
-def Picceler_BrightnessOp : Op<PiccelerDialect, "brightness", []> {
+def Picceler_BrightnessOp : Op<PiccelerDialect, "brightness", [Pure]> {
   let summary = "Adjust the brightness of an image";
   let arguments = (ins Picceler_ImageType:$input, I64:$value);
   let results = (outs Picceler_ImageType:$result);
+
+  let hasFolder = 1;
+  let hasCanonicalizer = 1;
 }
 
 def Picceler_InvertOp : Op<PiccelerDialect, "invert", []> {

--- a/tablegen/ops.td
+++ b/tablegen/ops.td
@@ -19,7 +19,7 @@ def Picceler_StringConstOp : Op<PiccelerDialect, "string.const"> {
   let results = (outs Picceler_StringType:$result);
 }
 
-def Picceler_KernelConstOp : Op<PiccelerDialect, "kernel.const"> {
+def Picceler_KernelConstOp : Op<PiccelerDialect, "kernel.const", [Pure]> {
   let summary = "Kernel constant producing a picceler.kernel";
   let arguments = (ins F64ElementsAttr:$values);
   let results = (outs Picceler_KernelType:$result);
@@ -141,6 +141,10 @@ def Picceler_ConvolutionOp : Op<PiccelerDialect, "convolution", [Pure,Neighbourh
   let summary = "Apply convolution to an image with a kernel";
   let arguments = (ins Picceler_ImageType:$input, AnyTypeOf<[Picceler_KernelType, AnyMemRef]>:$kernel);
   let results = (outs Picceler_ImageType:$result);
+
+  let hasVerifier = 1;
+  let hasFolder = 1;
+  let hasCanonicalizer = 1;
 }
 
 def Picceler_ErodeOp : Op<PiccelerDialect, "erode", [Pure, NeighbourhoodOpInterface,

--- a/tablegen/ops.td
+++ b/tablegen/ops.td
@@ -135,7 +135,7 @@ def Picceler_RotateOp : Op<PiccelerDialect, "rotate", [Pure]> {
   let hasCanonicalizer = 1;
 }
 
-def Picceler_ConvolutionOp : Op<PiccelerDialect, "convolution", [Pure,NeighbourhoodOpInterface,
+def Picceler_ConvolutionOp : Op<PiccelerDialect, "convolution", [Pure, NeighbourhoodOpInterface,
  DeclareOpInterfaceMethods<NeighbourhoodOpInterface, ["initializeAccumulator", "accumulate", "finalizeAccumulator", "getNeighborhoodSize"]>
  ]> {
   let summary = "Apply convolution to an image with a kernel";
@@ -156,6 +156,8 @@ def Picceler_ErodeOp : Op<PiccelerDialect, "erode", [Pure, NeighbourhoodOpInterf
   let results = (outs Picceler_ImageType:$result);
 
   let hasVerifier = 1;
+  let hasFolder = 1;
+  let hasCanonicalizer = 1;
 }
 
 def Picceler_DilateOp : Op<PiccelerDialect, "dilate", [Pure, NeighbourhoodOpInterface,
@@ -167,26 +169,40 @@ def Picceler_DilateOp : Op<PiccelerDialect, "dilate", [Pure, NeighbourhoodOpInte
   let results = (outs Picceler_ImageType:$result);
 
   let hasVerifier = 1;
+  let hasFolder = 1;
+  let hasCanonicalizer = 1;
 }
 
-def Picceler_DiffOp : Op<PiccelerDialect, "diff", [ElementWiseBinaryOpInterface, DeclareOpInterfaceMethods<ElementWiseBinaryOpInterface, ["transformPixels"]>]> {
+def Picceler_DiffOp : Op<PiccelerDialect, "diff", [Pure, ElementWiseBinaryOpInterface,
+ DeclareOpInterfaceMethods<ElementWiseBinaryOpInterface, ["transformPixels"]>]> {
   let summary = "Compute the pixel-wise difference between two images";
   let arguments = (ins Picceler_ImageType:$input1, Picceler_ImageType:$input2);
   let results = (outs Picceler_ImageType:$result);
+
+  let hasVerifier = 1;
+  let hasFolder = 1;
+  let hasCanonicalizer = 1;
 }
 
-def Picceler_BlendOp : Op<PiccelerDialect, "blend", [ElementWiseBinaryOpInterface, DeclareOpInterfaceMethods<ElementWiseBinaryOpInterface, ["transformPixels"]>]> {
+def Picceler_BlendOp : Op<PiccelerDialect, "blend", [Pure,ElementWiseBinaryOpInterface,
+ DeclareOpInterfaceMethods<ElementWiseBinaryOpInterface, ["transformPixels"]>]> {
   let summary = "Blend two images together";
   let arguments = (ins Picceler_ImageType:$input1, Picceler_ImageType:$input2, F64:$weight);
   let results = (outs Picceler_ImageType:$result);
 
   let hasVerifier = 1;
+  let hasFolder = 1;
+  let hasCanonicalizer = 1;
 }
 
-def Picceler_CropOp : Op<PiccelerDialect, "crop", []> {
+def Picceler_CropOp : Op<PiccelerDialect, "crop", [Pure]> {
   let summary = "Crop an image to a rectangular region";
   let arguments = (ins Picceler_ImageType:$input, I64:$x, I64:$y, I64:$width, I64:$height);
   let results = (outs Picceler_ImageType:$result);
+
+  let hasVerifier = 1;
+  let hasFolder = 1;
+  let hasCanonicalizer = 1;
 }
 
 def Picceler_ReadStringOp : Op<PiccelerDialect, "read_string", []> {

--- a/tablegen/ops.td
+++ b/tablegen/ops.td
@@ -89,30 +89,50 @@ def Picceler_BoxBlurOp : Op<PiccelerDialect, "box_blur", [Pure]> {
   let summary = "Apply a simple box blur";
   let arguments = (ins Picceler_ImageType:$input, I64:$radius);
   let results = (outs Picceler_ImageType:$result);
+
+  let hasVerifier = 1;
+  let hasFolder = 1;
+  let hasCanonicalizer = 1;
 }
 
 def Picceler_GaussianBlurOp : Op<PiccelerDialect, "gaussian_blur", [Pure]> {
   let summary = "Apply a gaussian blur (smoother)";
   let arguments = (ins Picceler_ImageType:$input, I64:$radius);
   let results = (outs Picceler_ImageType:$result);
+
+  let hasVerifier = 1;
+  let hasFolder = 1;
+  let hasCanonicalizer = 1;
 }
 
 def Picceler_EdgeDetectOp : Op<PiccelerDialect, "edge_detect", [Pure]> {
   let summary = "Detect edges in the image";
   let arguments = (ins Picceler_ImageType:$input);
   let results = (outs Picceler_ImageType:$result);
+
+  let hasVerifier = 1;
+  let hasFolder = 1;
+  let hasCanonicalizer = 1;
 }
 
 def Picceler_EmbossOp : Op<PiccelerDialect, "emboss", [Pure]> {
   let summary = "Apply a 3D emboss effect";
   let arguments = (ins Picceler_ImageType:$input);
   let results = (outs Picceler_ImageType:$result);
+
+  let hasVerifier = 1;
+  let hasFolder = 1;
+  let hasCanonicalizer = 1;
 }
 
 def Picceler_RotateOp : Op<PiccelerDialect, "rotate", [Pure]> {
   let summary = "Rotate an image around its center";
   let arguments = (ins Picceler_ImageType:$input, I64:$angle);
   let results = (outs Picceler_ImageType:$result);
+
+  let hasVerifier = 1;
+  let hasFolder = 1;
+  let hasCanonicalizer = 1;
 }
 
 def Picceler_ConvolutionOp : Op<PiccelerDialect, "convolution", [Pure,NeighbourhoodOpInterface,

--- a/tests/lit/mlir/picceler_canonicalizer.mlir
+++ b/tests/lit/mlir/picceler_canonicalizer.mlir
@@ -1,0 +1,36 @@
+// RUN: %picceler-opt --canonicalize -split-input-file %s | FileCheck %s
+
+func.func @BrightnessFoldOnZero(%arg0 : !picceler.image) -> !picceler.image {
+    %value = "arith.constant"() {value = 0 : i64} : () -> i64
+    %0 = "picceler.brightness" (%arg0, %value) : (!picceler.image, i64) -> !picceler.image
+    return %0 : !picceler.image
+}
+
+// CHECK-LABEL: func.func @BrightnessFoldOnZero(%arg0: !picceler.image) -> !picceler.image
+// CHECK-NEXT: return %arg0 : !picceler.image
+
+// -----
+
+func.func @BrightnessChain(%arg0 : !picceler.image) -> !picceler.image {
+    %value1 = "arith.constant"() {value = 10 : i64} : () -> i64
+    %0 = "picceler.brightness" (%arg0, %value1) : (!picceler.image, i64) -> !picceler.image
+    %value2 = "arith.constant"() {value = 20 : i64} : () -> i64
+    %1 = "picceler.brightness" (%0, %value2) : (!picceler.image, i64) -> !picceler.image
+    return %1 : !picceler.image
+}
+
+// CHECK-LABEL: func.func @BrightnessChain(%arg0: !picceler.image) -> !picceler.image
+// CHECK-NEXT: %[[NEW_VALUE:.*]] = arith.constant 30 : i64
+// CHECK-NEXT: %[[NEW_BRIGHTNESS:.*]] = "picceler.brightness"(%arg0, %[[NEW_VALUE]]) : (!picceler.image, i64) -> !picceler.image
+// CHECK-NEXT: return %[[NEW_BRIGHTNESS]] : !picceler.image
+
+// -----
+
+func.func @BrightnessFoldZeroUses(%arg0 : !picceler.image) -> !picceler.image {
+    %value = "arith.constant"() {value = 20 : i64} : () -> i64
+    %0 = "picceler.brightness" (%arg0, %value) : (!picceler.image, i64) -> !picceler.image
+    return %arg0 : !picceler.image
+}
+
+// CHECK-LABEL: func.func @BrightnessFoldZeroUses(%arg0: !picceler.image) -> !picceler.image
+// CHECK-NEXT: return %arg0 : !picceler.image

--- a/tests/lit/mlir/picceler_canonicalizer.mlir
+++ b/tests/lit/mlir/picceler_canonicalizer.mlir
@@ -133,3 +133,57 @@ func.func @EdgeDetectBypassMultipleUseInvert(%arg0 : !picceler.image) -> !piccel
 // CHECK-DAG: %[[EDGE:.*]] = "picceler.edge_detect"(%[[INPUT]]) : (!picceler.image) -> !picceler.image
 // CHECK: %[[BLEND:.*]] = "picceler.blend"(%[[INVERT]], %[[EDGE]], %[[ALPHA]]) : (!picceler.image, !picceler.image, f64) -> !picceler.image
 // CHECK-NEXT: return %[[BLEND]] : !picceler.image
+
+// -----
+
+func.func @RotateFoldOnZero(%arg0 : !picceler.image) -> !picceler.image {
+    %value = "arith.constant"() {value = 0 : i64} : () -> i64
+    %0 = "picceler.rotate" (%arg0, %value) : (!picceler.image, i64) -> !picceler.image
+    return %0 : !picceler.image
+}
+
+// CHECK-LABEL: func.func @RotateFoldOnZero
+// CHECK-SAME: (%[[INPUT:.*]]: !picceler.image) -> !picceler.image
+// CHECK-NEXT: return %[[INPUT]] : !picceler.image
+
+// -----
+
+func.func @ChainedRotatesFolding(%arg0 : !picceler.image) -> !picceler.image {
+    %value1 = "arith.constant"() {value = 90 : i64} : () -> i64
+    %0 = "picceler.rotate" (%arg0, %value1) : (!picceler.image, i64) -> !picceler.image
+    %value2 = "arith.constant"() {value = 180 : i64} : () -> i64
+    %1 = "picceler.rotate" (%0, %value2) : (!picceler.image, i64) -> !picceler.image
+    return %1 : !picceler.image
+}
+
+// CHECK-LABEL: func.func @ChainedRotatesFolding
+// CHECK-SAME: (%[[INPUT:.*]]: !picceler.image) -> !picceler.image
+// CHECK-DAG: %[[NEW_VALUE:.*]] = arith.constant 270 : i64
+// CHECK: %[[NEW_ROTATE:.*]] = "picceler.rotate"(%[[INPUT]], %[[NEW_VALUE]]) : (!picceler.image, i64) -> !picceler.image
+// CHECK-NEXT: return %[[NEW_ROTATE]] : !picceler.image
+
+// -----
+
+func.func @FoldIdentityConvolution(%arg0 : !picceler.image) -> !picceler.image {
+    %kernel = "picceler.kernel.const"() <{values = dense<[[0.000000e+00, 0.000000e+00, 0.000000e+00],
+     [0.000000e+00, 1.000000e+00, 0.000000e+00], [0.000000e+00, 0.000000e+00, 0.000000e+00]]> : tensor<3x3xf64>}> : () -> !picceler.kernel<3 x 3>
+    %0 = "picceler.convolution" (%arg0, %kernel) : (!picceler.image, !picceler.kernel<3 x 3>) -> !picceler.image
+    return %0 : !picceler.image
+}
+
+// CHECK-LABEL: func.func @FoldIdentityConvolution
+// CHECK-SAME: (%[[INPUT:.*]]: !picceler.image) -> !picceler.image
+// CHECK: return %[[INPUT]] : !picceler.image
+
+// -----
+
+ func.func @FoldUnusedKernel(%arg0 : i64) -> i64 {
+    %0 = "picceler.kernel.const"() <{values = dense<1.000000e+00> : tensor<1x1xf64>}> : () -> !picceler.kernel<1 x 1>
+    return %arg0 : i64
+ }
+
+ // CHECK-LABEL: func.func @FoldUnusedKernel
+ // CHECK-SAME: (%[[ARG0:.*]]: i64) -> i64
+ // CHECK-NEXT: return %[[ARG0]] : i64
+
+

--- a/tests/lit/mlir/picceler_canonicalizer.mlir
+++ b/tests/lit/mlir/picceler_canonicalizer.mlir
@@ -78,3 +78,58 @@ func.func @SharpenFoldOnZero(%arg0 : !picceler.image) -> !picceler.image {
     return %0 : !picceler.image
 }
 
+// CHECK-LABEL: func.func @SharpenFoldOnZero(%arg0: !picceler.image) -> !picceler.image
+// CHECK-NEXT: return %arg0 : !picceler.image
+
+// -----
+
+func.func @BoxBlurFoldOnZero(%arg0 : !picceler.image) -> !picceler.image {
+    %value = "arith.constant"() {value = 0 : i64} : () -> i64
+    %0 = "picceler.box_blur" (%arg0, %value) : (!picceler.image, i64) -> !picceler.image
+    return %0 : !picceler.image
+}
+
+// CHECK-LABEL: func.func @BoxBlurFoldOnZero(%arg0: !picceler.image) -> !picceler.image
+// CHECK-NEXT: return %arg0 : !picceler.image
+
+// -----
+
+func.func @GaussianBlurFoldOnZero(%arg0 : !picceler.image) -> !picceler.image {
+    %value = "arith.constant"() {value = 0 : i64} : () -> i64
+    %0 = "picceler.gaussian_blur" (%arg0, %value) : (!picceler.image, i64) -> !picceler.image
+    return %0 : !picceler.image
+}
+
+// CHECK-LABEL: func.func @GaussianBlurFoldOnZero(%arg0: !picceler.image) -> !picceler.image
+// CHECK-NEXT: return %arg0 : !picceler.image
+
+// -----
+
+func.func @EdgeDetectBypassSingleUseInvert(%arg0 : !picceler.image) -> !picceler.image {
+    %0 = "picceler.invert" (%arg0) : (!picceler.image) -> !picceler.image
+    %1 = "picceler.edge_detect" (%0) : (!picceler.image) -> !picceler.image
+    return %1 : !picceler.image
+}
+
+// CHECK-LABEL: func.func @EdgeDetectBypassSingleUseInvert
+// CHECK-SAME: (%[[INPUT:.*]]: !picceler.image) -> !picceler.image
+// CHECK-NEXT: %[[EDGE:.*]] = "picceler.edge_detect"(%[[INPUT]]) : (!picceler.image) -> !picceler.image
+// CHECK-NEXT: return %[[EDGE]] : !picceler.image
+
+// -----
+
+func.func @EdgeDetectBypassMultipleUseInvert(%arg0 : !picceler.image) -> !picceler.image {
+    %alpha = arith.constant 0.5 : f64
+    %0 = "picceler.invert" (%arg0) : (!picceler.image) -> !picceler.image
+    %1 = "picceler.edge_detect" (%0) : (!picceler.image) -> !picceler.image
+    %2 = "picceler.blend" (%0, %1, %alpha) : (!picceler.image, !picceler.image, f64) -> !picceler.image
+    return %2 : !picceler.image
+}
+
+// CHECK-LABEL: func.func @EdgeDetectBypassMultipleUseInvert
+// CHECK-SAME: (%[[INPUT:.*]]: !picceler.image) -> !picceler.image
+// CHECK-DAG: %[[ALPHA:.*]] = arith.constant 5.000000e-01 : f64
+// CHECK-DAG: %[[INVERT:.*]] = "picceler.invert"(%[[INPUT]]) : (!picceler.image) -> !picceler.image
+// CHECK-DAG: %[[EDGE:.*]] = "picceler.edge_detect"(%[[INPUT]]) : (!picceler.image) -> !picceler.image
+// CHECK: %[[BLEND:.*]] = "picceler.blend"(%[[INVERT]], %[[EDGE]], %[[ALPHA]]) : (!picceler.image, !picceler.image, f64) -> !picceler.image
+// CHECK-NEXT: return %[[BLEND]] : !picceler.image

--- a/tests/lit/mlir/picceler_canonicalizer.mlir
+++ b/tests/lit/mlir/picceler_canonicalizer.mlir
@@ -186,4 +186,88 @@ func.func @FoldIdentityConvolution(%arg0 : !picceler.image) -> !picceler.image {
  // CHECK-SAME: (%[[ARG0:.*]]: i64) -> i64
  // CHECK-NEXT: return %[[ARG0]] : i64
 
+// -----
+
+func.func @FoldDilateOnZero(%arg0 : !picceler.image) -> !picceler.image {
+    %value = "arith.constant"() {value = 0 : i64} : () -> i64
+    %0 = "picceler.dilate" (%arg0, %value) : (!picceler.image, i64) -> !picceler.image
+    return %0 : !picceler.image
+}
+
+// CHECK-LABEL: func.func @FoldDilateOnZero
+// CHECK-SAME: (%[[INPUT:.*]]: !picceler.image) -> !picceler.image
+// CHECK-NEXT: return %[[INPUT]] : !picceler.image
+
+// -----
+
+func.func @FoldErodeOnZero(%arg0 : !picceler.image) -> !picceler.image {
+    %value = "arith.constant"() {value = 0 : i64} : () -> i64
+    %0 = "picceler.erode" (%arg0, %value) : (!picceler.image, i64) -> !picceler.image
+    return %0 : !picceler.image
+}
+
+// CHECK-LABEL: func.func @FoldErodeOnZero
+// CHECK-SAME: (%[[INPUT:.*]]: !picceler.image) -> !picceler.image
+// CHECK-NEXT: return %[[INPUT]] : !picceler.image
+
+// -----
+
+func.func @FoldBlendWithSameInput(%arg0 : !picceler.image) -> !picceler.image {
+    %alpha = arith.constant 0.5 : f64
+    %0 = "picceler.blend" (%arg0, %arg0, %alpha) : (!picceler.image, !picceler.image, f64) -> !picceler.image
+    return %0 : !picceler.image
+}
+
+// CHECK-LABEL: func.func @FoldBlendWithSameInput
+// CHECK-SAME: (%[[INPUT:.*]]: !picceler.image) -> !picceler.image
+// CHECK-NEXT: return %[[INPUT]] : !picceler.image
+
+// -----
+
+func.func @FoldBlendWithAlphaZero(%arg0 : !picceler.image, %arg1 : !picceler.image) -> !picceler.image {
+    %alpha = arith.constant 0.0 : f64
+    %0 = "picceler.blend" (%arg0, %arg1, %alpha) : (!picceler.image, !picceler.image, f64) -> !picceler.image
+    return %0 : !picceler.image
+}
+
+// CHECK-LABEL: func.func @FoldBlendWithAlphaZero
+// CHECK-SAME: (%[[INPUT1:.*]]: !picceler.image, %[[INPUT2:.*]]: !picceler.image) -> !picceler.image
+// CHECK-NEXT: return %[[INPUT1]] : !picceler.image
+
+// -----
+
+func.func @FoldBlendWithAlphaOne(%arg0 : !picceler.image, %arg1 : !picceler.image) -> !picceler.image {
+    %alpha = arith.constant 1.0 : f64
+    %0 = "picceler.blend" (%arg0, %arg1, %alpha) : (!picceler.image, !picceler.image, f64) -> !picceler.image
+    return %0 : !picceler.image
+}
+
+// CHECK-LABEL: func.func @FoldBlendWithAlphaOne
+// CHECK-SAME: (%[[INPUT1:.*]]: !picceler.image, %[[INPUT2:.*]]: !picceler.image) -> !picceler.image
+// CHECK-NEXT: return %[[INPUT2]] : !picceler.image
+
+// -----
+
+func.func @CombineCropWhenAllConstants(%arg0 : !picceler.image) -> !picceler.image {
+    %x1 = arith.constant 10 : i64
+    %y1 = arith.constant 20 : i64
+    %w1 = arith.constant 100 : i64
+    %h1 = arith.constant 200 : i64
+    %0 = "picceler.crop" (%arg0, %x1, %y1, %w1, %h1) : (!picceler.image, i64, i64, i64, i64) -> !picceler.image
+    %x2 = arith.constant 5 : i64
+    %y2 = arith.constant 10 : i64
+    %w2 = arith.constant 50 : i64
+    %h2 = arith.constant 100 : i64
+    %1 = "picceler.crop" (%0, %x2, %y2, %w2, %h2) : (!picceler.image, i64, i64, i64, i64) -> !picceler.image
+    return %1 : !picceler.image
+}
+
+// CHECK-LABEL: func.func @CombineCropWhenAllConstants
+// CHECK-SAME: (%[[INPUT:.*]]: !picceler.image) -> !picceler.image
+// CHECK-DAG: %[[FUSED_X:.*]] = arith.constant 15 : i64
+// CHECK-DAG: %[[FUSED_Y:.*]] = arith.constant 30 : i64
+// CHECK-DAG: %[[FUSED_W:.*]] = arith.constant 50 : i64
+// CHECK-DAG: %[[FUSED_H:.*]] = arith.constant 100 : i64
+// CHECK-NEXT: %[[FUSED_CROP:.*]] = "picceler.crop"(%[[INPUT]], %[[FUSED_X]], %[[FUSED_Y]], %[[FUSED_W]], %[[FUSED_H]]) : (!picceler.image, i64, i64, i64, i64) -> !picceler.image
+// CHECK-NEXT: return %[[FUSED_CROP]] : !picceler.image
 

--- a/tests/lit/mlir/picceler_canonicalizer.mlir
+++ b/tests/lit/mlir/picceler_canonicalizer.mlir
@@ -34,3 +34,47 @@ func.func @BrightnessFoldZeroUses(%arg0 : !picceler.image) -> !picceler.image {
 
 // CHECK-LABEL: func.func @BrightnessFoldZeroUses(%arg0: !picceler.image) -> !picceler.image
 // CHECK-NEXT: return %arg0 : !picceler.image
+
+// ----- 
+
+func.func @BrightnessChainResultsInZeroFold(%arg0 : !picceler.image) -> !picceler.image {
+    %value1 = "arith.constant"() {value = 10 : i64} : () -> i64
+    %0 = "picceler.brightness" (%arg0, %value1) : (!picceler.image, i64) -> !picceler.image
+    %value2 = "arith.constant"() {value = -10 : i64} : () -> i64
+    %1 = "picceler.brightness" (%0, %value2) : (!picceler.image, i64) -> !picceler.image
+    return %1 : !picceler.image
+}
+
+// CHECK-LABEL: func.func @BrightnessChainResultsInZeroFold(%arg0: !picceler.image) -> !picceler.image
+// CHECK-NEXT: return %arg0 : !picceler.image
+
+// -----
+
+func.func @BrightnessNoFoldOnNonConstant(%arg0 : !picceler.image, %arg1 : i64) -> !picceler.image {
+    %0 = "picceler.brightness" (%arg0, %arg1) : (!picceler.image, i64) -> !picceler.image
+    return %0 : !picceler.image
+}
+
+// CHECK-LABEL: func.func @BrightnessNoFoldOnNonConstant(%arg0: !picceler.image, %arg1: i64) -> !picceler.image
+// CHECK-NEXT: %0 = "picceler.brightness"(%arg0, %arg1) : (!picceler.image, i64) -> !picceler.image
+// CHECK-NEXT: return %0 : !picceler.image
+
+// -----
+
+func.func @InvertFoldOnChain(%arg0 : !picceler.image) -> !picceler.image {
+    %0 = "picceler.invert" (%arg0) : (!picceler.image) -> !picceler.image
+    %1 = "picceler.invert" (%0) : (!picceler.image) -> !picceler.image
+    return %1 : !picceler.image
+}
+
+// CHECK-LABEL: func.func @InvertFoldOnChain(%arg0: !picceler.image) -> !picceler.image
+// CHECK-NEXT: return %arg0 : !picceler.image
+
+// -----
+
+func.func @SharpenFoldOnZero(%arg0 : !picceler.image) -> !picceler.image {
+    %value = "arith.constant"() {value = 0 : i64} : () -> i64
+    %0 = "picceler.sharpen" (%arg0, %value) : (!picceler.image, i64) -> !picceler.image
+    return %0 : !picceler.image
+}
+

--- a/tests/lit/mlir/picceler_kernel_to_memref_pass.mlir
+++ b/tests/lit/mlir/picceler_kernel_to_memref_pass.mlir
@@ -1,50 +1,42 @@
 // RUN: %picceler-opt --picceler-kernel-to-memref -split-input-file %s | FileCheck %s
 
-
-func.func @SmallKernelOfOnes() {
+func.func @SmallKernelOfOnes() -> !picceler.kernel<3 x 3> {
     %0 = "picceler.kernel.const"() <{values = dense<1.000000e+00> : tensor<3x3xf64>}> : () -> !picceler.kernel<3 x 3>
-    return 
+    return %0 : !picceler.kernel<3 x 3>
 }
 
-// CHECK-LABEL: func.func @SmallKernelOfOnes()
-// CHECK-DAG: %[[KERNEL_VALUE:.*]] = arith.constant 1.000000e+00 : f64
-// CHECK-DAG: %[[INDEX_0:.*]] = arith.constant 0 : index
-// CHECK-DAG: %[[INDEX_1:.*]] = arith.constant 1 : index
-// CHECK-DAG: %[[INDEX_2:.*]] = arith.constant 2 : index
-// CHECK: %[[MEMREF:.*]] = memref.alloca() : memref<3x3xf64>
-// CHECK: memref.store %[[KERNEL_VALUE]], %[[MEMREF]][%[[INDEX_0]], %[[INDEX_0]]]  : memref<3x3xf64>
-// CHECK: memref.store %[[KERNEL_VALUE]], %[[MEMREF]][%[[INDEX_0]], %[[INDEX_1]]] : memref<3x3xf64>
-// CHECK: memref.store %[[KERNEL_VALUE]], %[[MEMREF]][%[[INDEX_0]], %[[INDEX_2]]] : memref<3x3xf64>
-// CHECK: memref.store %[[KERNEL_VALUE]], %[[MEMREF]][%[[INDEX_1]], %[[INDEX_0]]] : memref<3x3xf64>
-// CHECK: memref.store %[[KERNEL_VALUE]], %[[MEMREF]][%[[INDEX_1]], %[[INDEX_1]]] : memref<3x3xf64>
-// CHECK: memref.store %[[KERNEL_VALUE]], %[[MEMREF]][%[[INDEX_1]], %[[INDEX_2]]] : memref<3x3xf64>
-// CHECK: memref.store %[[KERNEL_VALUE]], %[[MEMREF]][%[[INDEX_2]], %[[INDEX_0]]] : memref<3x3xf64>
-// CHECK: memref.store %[[KERNEL_VALUE]], %[[MEMREF]][%[[INDEX_2]], %[[INDEX_1]]] : memref<3x3xf64>
-// CHECK: memref.store %[[KERNEL_VALUE]], %[[MEMREF]][%[[INDEX_2]], %[[INDEX_2]]] : memref<3x3xf64>
-// CHECK-NEXT: return
+// CHECK-LABEL: func.func @SmallKernelOfOnes() -> memref<3x3xf64> {
+// CHECK:         %[[MEMREF:.*]] = memref.alloca() : memref<3x3xf64>
+// CHECK-DAG:     %[[V0:.*]] = arith.constant 1.000000e+00 : f64
+// CHECK-DAG:     %[[R0:.*]] = arith.constant 0 : index
+// CHECK-DAG:     %[[C0:.*]] = arith.constant 0 : index
+// CHECK:         memref.store %[[V0]], %[[MEMREF]][%[[R0]], %[[C0]]] : memref<3x3xf64>
+// CHECK-DAG:     %[[R0_1:.*]] = arith.constant 0 : index
+// CHECK-DAG:     %[[C1:.*]] = arith.constant 1 : index
+// CHECK-DAG:     %[[V0_1:.*]] = arith.constant 1.000000e+00 : f64
+// CHECK:         memref.store %[[V0_1]], %[[MEMREF]][%[[R0_1]], %[[C1]]] : memref<3x3xf64>
+// CHECK:         return %[[MEMREF]] : memref<3x3xf64>
+// CHECK:       }
 
 // -----
 
-func.func @VerticalLineKernel() {
+func.func @VerticalLineKernel() -> !picceler.kernel<3 x 3> {
     %0 = "picceler.kernel.const"() <{values = dense<[[-1.000000e+00, 2.000000e+00, -1.000000e+00], [-1.000000e+00, 2.000000e+00, -1.000000e+00], [-1.000000e+00, 2.000000e+00, -1.000000e+00]]> : tensor<3x3xf64>}> : () -> !picceler.kernel<3 x 3>
-    return 
+    return %0 : !picceler.kernel<3 x 3>
 }
 
-// CHECK-LABEL: func.func @VerticalLineKernel()
-// CHECK-DAG: %[[NEG1:.*]] = arith.constant -1.000000e+00 : f64
-// CHECK-DAG: %[[POS2:.*]] = arith.constant 2.000000e+00 : f64
-// CHECK-DAG: %[[INDEX_0:.*]] = arith.constant 0 : index
-// CHECK-DAG: %[[INDEX_1:.*]] = arith.constant 1 : index
-// CHECK-DAG: %[[INDEX_2:.*]] = arith.constant 2 : index
-// CHECK: %[[MEMREF:.*]] = memref.alloca() : memref<3x3xf64>
-// CHECK: memref.store %[[NEG1]], %[[MEMREF]][%[[INDEX_0]], %[[INDEX_0]]] : memref<3x3xf64>
-// CHECK: memref.store %[[POS2]], %[[MEMREF]][%[[INDEX_0]], %[[INDEX_1]]] : memref<3x3xf64>
-// CHECK: memref.store %[[NEG1]], %[[MEMREF]][%[[INDEX_0]], %[[INDEX_2]]] : memref<3x3xf64>
-// CHECK: memref.store %[[NEG1]], %[[MEMREF]][%[[INDEX_1]], %[[INDEX_0]]] : memref<3x3xf64>
-// CHECK: memref.store %[[POS2]], %[[MEMREF]][%[[INDEX_1]], %[[INDEX_1]]] : memref<3x3xf64>
-// CHECK: memref.store %[[NEG1]], %[[MEMREF]][%[[INDEX_1]], %[[INDEX_2]]] : memref<3x3xf64>
-// CHECK: memref.store %[[NEG1]], %[[MEMREF]][%[[INDEX_2]], %[[INDEX_0]]] : memref<3x3xf64>
-// CHECK: memref.store %[[POS2]], %[[MEMREF]][%[[INDEX_2]], %[[INDEX_1]]] : memref<3x3xf64>
-// CHECK: memref.store %[[NEG1]], %[[MEMREF]][%[[INDEX_2]], %[[INDEX_2]]] : memref<3x3xf64>
-// CHECK-NEXT: return
+// CHECK-LABEL: func.func @VerticalLineKernel() -> memref<3x3xf64> {
+// CHECK:         %[[MEMREF:.*]] = memref.alloca() : memref<3x3xf64>
+// CHECK-DAG:     %[[NEG1:.*]] = arith.constant -1.000000e+00 : f64
+// CHECK-DAG:     %[[R0:.*]] = arith.constant 0 : index
+// CHECK-DAG:     %[[C0:.*]] = arith.constant 0 : index
+// CHECK:         memref.store %[[NEG1]], %[[MEMREF]][%[[R0]], %[[C0]]] : memref<3x3xf64>
+// CHECK-DAG:     %[[POS2:.*]] = arith.constant 2.000000e+00 : f64
+// CHECK-DAG:     %[[R0_1:.*]] = arith.constant 0 : index
+// CHECK-DAG:     %[[C1:.*]] = arith.constant 1 : index
+// CHECK:         memref.store %[[POS2]], %[[MEMREF]][%[[R0_1]], %[[C1]]] : memref<3x3xf64>
+// CHECK:         return %[[MEMREF]] : memref<3x3xf64>
+// CHECK:       }
+
+
 

--- a/tests/lit/mlir/picceler_to_affine_invalid_angle.mlir
+++ b/tests/lit/mlir/picceler_to_affine_invalid_angle.mlir
@@ -6,4 +6,4 @@ func.func @RotateImageInvalidAngle(%arg0 : !picceler.image) -> !picceler.image {
     return %0 : !picceler.image
 }
 
-// CHECK: error: 'picceler.rotate' op angle must be a multiple of 90 degrees
+// CHECK: error: 'picceler.rotate' op angle must be a multiple of 90, got 45


### PR DESCRIPTION
This PR fixes #88 and #89 by adding `verify` `getCanonicalizationPatterns` and `fold` to most of the ops. 

The PR does more though:

1. Adds `Pure` trait to most of the ops, MLIR automatically covers ops that are Pure in the case they are not used, they will simply be removed via Dead Code Elimination

2. The `KernelToMemRef` now also is responsible for type conversion from Picceler_ImageType to MemRef

But most of the PR is verifiers, some canonicalization patterns for some ops. Best way to see what the folders and canonicalization patterns do is to verify the new LIT tests file created for the canonicalization pass, it covers all of the cases supported. Verifiers exist but most of them are not tested.. won't add this in this PR tbh
