### PR TITLE
Support pow and sqrt op.

### DIFF
--- a/examples/binary_operations.pic
+++ b/examples/binary_operations.pic
@@ -1,0 +1,7 @@
+root_val = sqrt(25.0)
+cubed = pow(2.0, 3.0)
+complex_calc = -1 + 2 * 3 + root_val + cubed
+
+if (complex_calc == 18){
+    print("Binary operations passed successfully! \n")
+}

--- a/src/compiler.cpp
+++ b/src/compiler.cpp
@@ -5,6 +5,7 @@
 #include <string_view>
 #include <vector>
 
+#include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -160,6 +161,7 @@ mlir::DialectRegistry Compiler::initRegistry() {
   registry.insert<mlir::memref::MemRefDialect>();
   registry.insert<mlir::scf::SCFDialect>();
   registry.insert<mlir::LLVM::LLVMDialect>();
+  registry.insert<mlir::math::MathDialect>();
   mlir::registerBuiltinDialectTranslation(registry);
   mlir::registerLLVMDialectTranslation(registry);
   return registry;

--- a/src/mlir_gen.cpp
+++ b/src/mlir_gen.cpp
@@ -193,8 +193,6 @@ void MLIRGen::defineUserFunctions(mlir::ModuleOp module, ModuleNode *root) {
 mlir::ModuleOp MLIRGen::generate(ModuleNode *root, const std::string &sourceFile) {
   _sourceFile = sourceFile;
 
-  _context->getOrLoadDialect<mlir::math::MathDialect>();
-
   auto module = mlir::ModuleOp::create(_builder.getUnknownLoc());
   registerBuiltinFunctions();
 

--- a/src/mlir_gen.cpp
+++ b/src/mlir_gen.cpp
@@ -11,6 +11,7 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/Dialect.h"
+#include "mlir/Dialect/Math/IR/Math.h"
 
 #include "ops.h"
 #include "types.h"
@@ -191,6 +192,9 @@ void MLIRGen::defineUserFunctions(mlir::ModuleOp module, ModuleNode *root) {
 
 mlir::ModuleOp MLIRGen::generate(ModuleNode *root, const std::string &sourceFile) {
   _sourceFile = sourceFile;
+
+  _context->getOrLoadDialect<mlir::math::MathDialect>();
+
   auto module = mlir::ModuleOp::create(_builder.getUnknownLoc());
   registerBuiltinFunctions();
 
@@ -472,6 +476,31 @@ void MLIRGen::registerBuiltinFunctions() {
 
     _builder.create<PrintOp>(loc, fmt, variadicArgs);
     return mlir::Value(); // Return an empty value for void functions
+  };
+
+  _functionTable["sqrt"] = [&](mlir::Location loc, const std::vector<mlir::Value> &args) {
+    if (args.size() != 1) {
+      throw std::runtime_error("sqrt expects 1 argument");
+    }
+    auto &arg = args[0];
+    
+    // Optional: Ensure it's a float or can be treated as one
+    if (!mlir::isa<mlir::FloatType>(arg.getType())) {
+      throw std::runtime_error("sqrt expects a floating-point argument");
+    }
+
+    auto callOp = _builder.create<mlir::math::SqrtOp>(loc, arg);
+    return callOp.getResult();
+  };
+
+  _functionTable["pow"] = [&](mlir::Location loc, const std::vector<mlir::Value> &args) {
+    if (args.size() != 2) {
+      throw std::runtime_error("pow expects 2 arguments");
+    }
+    auto &base = args[0];
+    auto &exp = args[1];
+    auto callOp = _builder.create<mlir::math::PowFOp>(loc, base, exp);
+    return callOp.getResult();
   };
 }
 

--- a/tests/unit/src/parser_tests.cpp
+++ b/tests/unit/src/parser_tests.cpp
@@ -203,4 +203,46 @@ TEST_F(ParserTest, RelationalComparisonExpression) {
   ASSERT_EQ(ast->statements().size(), 3);
 }
 
+TEST_F(ParserTest, SqrtFunctionParses) {
+  auto ast = parseSuccessfully("res = sqrt(16.0)");
+  ASSERT_NE(ast, nullptr);
+  ASSERT_EQ(ast->statements().size(), 1);
+
+  const auto *assign = as<AssignmentNode>(ast->statements()[0]);
+  ASSERT_NE(assign, nullptr);
+  EXPECT_EQ(assign->lhs()->name(), "res");
+
+  const auto *call = as<CallNode>(assign->rhs());
+  ASSERT_NE(call, nullptr);
+  EXPECT_EQ(call->callee(), "sqrt");
+  ASSERT_EQ(call->arguments().size(), 1);
+
+  const auto *arg = as<NumberNode>(call->arguments()[0]);
+  ASSERT_NE(arg, nullptr);
+  EXPECT_EQ(arg->value(), 16.0);
+}
+
+TEST_F(ParserTest, PowFunctionParses) {
+  auto ast = parseSuccessfully("res = pow(2.0, 3.0)");
+  ASSERT_NE(ast, nullptr);
+  ASSERT_EQ(ast->statements().size(), 1);
+
+  const auto *assign = as<AssignmentNode>(ast->statements()[0]);
+  ASSERT_NE(assign, nullptr);
+  EXPECT_EQ(assign->lhs()->name(), "res");
+
+  const auto *call = as<CallNode>(assign->rhs());
+  ASSERT_NE(call, nullptr);
+  EXPECT_EQ(call->callee(), "pow");
+  ASSERT_EQ(call->arguments().size(), 2);
+
+  const auto *base = as<NumberNode>(call->arguments()[0]);
+  ASSERT_NE(base, nullptr);
+  EXPECT_EQ(base->value(), 2.0);
+
+  const auto *exp = as<NumberNode>(call->arguments()[1]);
+  ASSERT_NE(exp, nullptr);
+  EXPECT_EQ(exp->value(), 3.0);
+}
+
 } // namespace picceler


### PR DESCRIPTION
Fixes #85 .

Implement support for binary operations like pow and sqrt.
Other operations and precedence rules was implemented in previous pr.