### PR TITLE
Refactor use of ImageAccessHelper in favor of memref

### DIFF
--- a/include/passes.h
+++ b/include/passes.h
@@ -4,7 +4,24 @@
 
 #include "mlir/Pass/Pass.h"
 
+#include "mlir/Dialect/Func/Transforms/FuncConversions.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
+
 namespace picceler {
+
+/**
+ * @brief A generic pattern that updates the types of operations based on a provided type converter.
+ * Used in KernelToMemref and OpsToFuncCalls passes to ensure that operations have the correct types after type
+ * conversion.
+ */
+struct GenericTypeUpdatePattern : public mlir::ConversionPattern {
+  GenericTypeUpdatePattern(mlir::TypeConverter &converter, mlir::MLIRContext *context)
+      : mlir::ConversionPattern(converter, MatchAnyOpTypeTag(), 1, context) {}
+
+  mlir::LogicalResult matchAndRewrite(mlir::Operation *op, mlir::ArrayRef<mlir::Value> operands,
+                                      mlir::ConversionPatternRewriter &rewriter) const override;
+};
 
 /**
  * @name The following functions create instances of the various passes used in the compilation process.

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -15,6 +15,8 @@ add_library(${RUNTIME_LIB_NAME} STATIC
 
 target_include_directories(${RUNTIME_LIB_NAME} PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${LLVM_INCLUDE_DIRS}
+    ${MLIR_INCLUDE_DIRS}
 )
 
 target_link_libraries(${RUNTIME_LIB_NAME}

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -15,8 +15,6 @@ add_library(${RUNTIME_LIB_NAME} STATIC
 
 target_include_directories(${RUNTIME_LIB_NAME} PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/include
-    ${LLVM_INCLUDE_DIRS}
-    ${MLIR_INCLUDE_DIRS}
 )
 
 target_link_libraries(${RUNTIME_LIB_NAME}

--- a/lib/include/image.h
+++ b/lib/include/image.h
@@ -10,6 +10,7 @@ namespace picceler {
 class Image {
 public:
   Image() : _width(0), _height(0), _data(nullptr) {}
+  Image(uint32_t width, uint32_t height, unsigned char *data) : _width(width), _height(height), _data(data) {}
 
   uint32_t _width;
   uint32_t _height;

--- a/lib/include/runtime.h
+++ b/lib/include/runtime.h
@@ -2,8 +2,6 @@
 
 #include "image.h"
 
-#include "mlir/ExecutionEngine/CRunnerUtils.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/lib/include/runtime.h
+++ b/lib/include/runtime.h
@@ -2,6 +2,8 @@
 
 #include "image.h"
 
+#include "mlir/ExecutionEngine/CRunnerUtils.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -11,10 +13,10 @@ extern "C" {
  * \{
  */
 
-picceler::Image *piccelerLoadImage(const char *filename);
-void piccelerShowImage(picceler::Image *image);
-void piccelerSaveImage(picceler::Image *image, const char *filename);
-picceler::Image *piccelerCreateImage(uint32_t width, uint32_t height);
+void piccelerLoadImage(const char *filename, uint8_t **data, int64_t *height, int64_t *width);
+void piccelerShowImage(void *data, uint32_t width, uint32_t height);
+void piccelerSaveImage(void *data, uint32_t width, uint32_t height, const char *filename);
+
 void *piccelerReadString(const char *prompt);
 double piccelerReadNumber(const char *prompt);
 

--- a/lib/src/runtime.cpp
+++ b/lib/src/runtime.cpp
@@ -1,5 +1,6 @@
 #include "runtime.h"
 
+#include <cstddef>
 #include <iostream>
 
 #include "spdlog/spdlog.h"
@@ -8,35 +9,30 @@
 
 extern "C" {
 
-picceler::Image *piccelerLoadImage(const char *filename) {
-  spdlog::debug("piccelerLoadImage called with filename: {}", filename);
-  picceler::Image *imgPtr = picceler::loadImage(std::string(filename));
-  spdlog::debug("Size: {}, Width Off: {}, Height Off: {}, Data Off: {}", sizeof(picceler::Image),
-                offsetof(picceler::Image, _width), offsetof(picceler::Image, _height),
-                offsetof(picceler::Image, _data));
+void piccelerLoadImage(const char *filename, uint8_t **data, int64_t *height, int64_t *width) {
+  picceler::Image *img = picceler::loadImage(std::string(filename));
+  if (!img || !img->_data) {
+    *data = nullptr;
+    *height = 0;
+    *width = 0;
+    return;
+  }
 
-  return imgPtr;
+  *data = img->_data;
+  *height = static_cast<int64_t>(img->_height);
+  *width = static_cast<int64_t>(img->_width);
 }
 
-void piccelerShowImage(picceler::Image *image) {
+void piccelerShowImage(void *data, uint32_t width, uint32_t height) {
   spdlog::debug("piccelerShowImage called");
-  picceler::showImage(*image);
+  picceler::Image image{width, height, static_cast<unsigned char *>(data)};
+  picceler::showImage(image);
 }
 
-void piccelerSaveImage(picceler::Image *image, const char *filename) {
+void piccelerSaveImage(void *data, uint32_t width, uint32_t height, const char *filename) {
   spdlog::debug("piccelerSaveImage called with filename: {}", filename);
-  picceler::saveImage(*image, std::string(filename));
-}
-
-picceler::Image *piccelerCreateImage(uint32_t width, uint32_t height) {
-  spdlog::debug("piccelerCreateImage called with width: {}, height: {}", width, height);
-  picceler::Image *newImage = new picceler::Image();
-  newImage->_width = width;
-  newImage->_height = height;
-  constexpr auto channels = 4;
-  newImage->_data = new unsigned char[static_cast<size_t>(width) * height * channels];
-
-  return newImage;
+  picceler::Image image{width, height, static_cast<unsigned char *>(data)};
+  picceler::saveImage(image, std::string(filename));
 }
 
 void *piccelerReadString(const char *prompt) {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -79,6 +79,7 @@ target_link_libraries(PiccelerIR PUBLIC
 )
 
 add_library(PiccelerTransforms STATIC
+    generic_type_rewriter.cpp
     picceler_kernel_to_memref_pass.cpp
     picceler_ops_to_func_calls_pass.cpp
     picceler_to_affine_pass.cpp

--- a/src/generic_type_rewriter.cpp
+++ b/src/generic_type_rewriter.cpp
@@ -1,0 +1,22 @@
+#include "passes.h"
+
+namespace picceler {
+
+mlir::LogicalResult GenericTypeUpdatePattern::matchAndRewrite(mlir::Operation *op, mlir::ArrayRef<mlir::Value> operands,
+                                                              mlir::ConversionPatternRewriter &rewriter) const {
+
+  if (getTypeConverter()->isLegal(op))
+    return mlir::failure();
+
+  mlir::SmallVector<mlir::Type> newResultTypes;
+  if (mlir::failed(getTypeConverter()->convertTypes(op->getResultTypes(), newResultTypes)))
+    return mlir::failure();
+
+  mlir::OperationState state(op->getLoc(), op->getName().getStringRef(), operands, newResultTypes, op->getAttrs());
+  mlir::Operation *newOp = rewriter.create(state);
+
+  rewriter.replaceOp(op, newOp->getResults());
+  return mlir::success();
+}
+
+} // namespace picceler

--- a/src/pass_manager.cpp
+++ b/src/pass_manager.cpp
@@ -41,8 +41,8 @@ IRPassManager::IRPassManager(mlir::MLIRContext *context) : _passManager(context)
 bool IRPassManager::run(mlir::ModuleOp module) { return !mlir::failed(_passManager.run(module)); }
 
 void IRPassManager::addPasses() {
-  addRuntimeLoweringPasses();
   addHighLevelOptimizationPasses();
+  addRuntimeLoweringPasses();
   addAffineLoweringPasses();
   addBackendLoweringPasses();
 }

--- a/src/picceler_kernel_to_memref_pass.cpp
+++ b/src/picceler_kernel_to_memref_pass.cpp
@@ -7,9 +7,12 @@
 #include "mlir/IR/Builders.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/DialectConversion.h"
+#include "mlir/IR/BuiltinDialect.h"
+#include "mlir/IR/BuiltinOps.h"
 
 #include "ops.h"
 #include "types.h"
+#include "passes.h"
 
 namespace picceler {
 
@@ -74,6 +77,7 @@ struct PiccelerKernelToMemrefPass : public impl::PiccelerKernelToMemrefBase<Picc
 
     mlir::RewritePatternSet patterns(&context);
     patterns.add<KernelToMemref>(typeConverter, &context);
+    patterns.add<GenericTypeUpdatePattern>(typeConverter, &context);
 
     mlir::populateFunctionOpInterfaceTypeConversionPattern<mlir::func::FuncOp>(patterns, typeConverter);
     mlir::populateReturnOpTypeConversionPattern(patterns, typeConverter);
@@ -81,11 +85,13 @@ struct PiccelerKernelToMemrefPass : public impl::PiccelerKernelToMemrefBase<Picc
     mlir::ConversionTarget target(context);
     target.addIllegalOp<KernelConstOp>();
     target.addLegalDialect<mlir::arith::ArithDialect, mlir::memref::MemRefDialect, mlir::func::FuncDialect>();
+    // target.addLegalOp<mlir::UnrealizedConversionCastOp>();
 
     target.addDynamicallyLegalOp<mlir::func::FuncOp>(
         [&](mlir::func::FuncOp op) { return typeConverter.isSignatureLegal(op.getFunctionType()); });
     target.addDynamicallyLegalOp<mlir::func::ReturnOp>(
         [&](mlir::func::ReturnOp op) { return typeConverter.isLegal(op.getOperandTypes()); });
+    target.markUnknownOpDynamicallyLegal([&](mlir::Operation *op) { return typeConverter.isLegal(op); });
 
     if (mlir::failed(mlir::applyPartialConversion(getOperation(), target, std::move(patterns)))) {
       signalPassFailure();

--- a/src/picceler_ops_to_func_calls_pass.cpp
+++ b/src/picceler_ops_to_func_calls_pass.cpp
@@ -5,9 +5,15 @@
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 
 #include "ops.h"
 #include "types.h"
+#include "image_access_helper.h"
+#include <mlir/IR/BuiltinDialect.h>
+#include <mlir/IR/BuiltinOps.h>
 
 namespace picceler {
 
@@ -37,29 +43,68 @@ mlir::func::FuncOp ensureRuntimeFunc(mlir::ModuleOp module, mlir::StringRef name
   return func;
 }
 
-/**
- * @brief Pattern to lower LoadImageOp to a function call.
- */
 struct LoadImageToCall : public mlir::OpConversionPattern<LoadImageOp> {
   using mlir::OpConversionPattern<LoadImageOp>::OpConversionPattern;
 
   mlir::LogicalResult matchAndRewrite(LoadImageOp op, LoadImageOpAdaptor adaptor,
                                       mlir::ConversionPatternRewriter &rewriter) const override {
-
     auto module = op->getParentOfType<mlir::ModuleOp>();
-    auto ctx = rewriter.getContext();
     auto loc = op.getLoc();
+    auto *ctx = rewriter.getContext();
+
+    auto i8Ty = rewriter.getIntegerType(8);
+    auto i64Ty = rewriter.getI64Type();
+    auto ptrTy = mlir::LLVM::LLVMPointerType::get(ctx);
 
     auto stringType = StringType::get(ctx);
-    auto imageType = ImageType::get(ctx);
 
-    auto func = ensureRuntimeFunc(module, "piccelerLoadImage", {stringType}, {imageType}, rewriter, loc);
-    llvm::SmallVector<mlir::Value, 1> args;
-    args.push_back(adaptor.getFilename());
+    // void piccelerLoadImage(!picceler.string, !llvm.ptr, !llvm.ptr, !llvm.ptr)
+    // args: filename, &data, &height, &width
+    auto fn = ensureRuntimeFunc(module, "piccelerLoadImage",
+                                /*inputs=*/{stringType, ptrTy, ptrTy, ptrTy},
+                                /*results=*/{}, rewriter, loc);
 
-    auto call = rewriter.create<mlir::func::CallOp>(loc, func, args);
-    rewriter.replaceOp(op, call.getResults());
+    auto c1_i32 = rewriter.create<mlir::arith::ConstantIntOp>(loc, 1, 32).getResult();
 
+    // LLVM alloca signature in your build expects:
+    // (resultType, elementType, arraySize, alignment)
+    auto dataSlot = rewriter.create<mlir::LLVM::AllocaOp>(loc, ptrTy, ptrTy, c1_i32, /*alignment=*/0);
+    auto hSlot = rewriter.create<mlir::LLVM::AllocaOp>(loc, ptrTy, i64Ty, c1_i32, /*alignment=*/0);
+    auto wSlot = rewriter.create<mlir::LLVM::AllocaOp>(loc, ptrTy, i64Ty, c1_i32, /*alignment=*/0);
+
+    // call runtime
+    rewriter.create<mlir::func::CallOp>(
+        loc, fn, mlir::ValueRange{adaptor.getFilename(), dataSlot.getResult(), hSlot.getResult(), wSlot.getResult()});
+
+    // loads return ops; take Value via getResult()
+    auto dataPtr = rewriter.create<mlir::LLVM::LoadOp>(loc, ptrTy, dataSlot.getResult()).getResult();
+    auto h64 = rewriter.create<mlir::LLVM::LoadOp>(loc, i64Ty, hSlot.getResult()).getResult();
+    auto w64 = rewriter.create<mlir::LLVM::LoadOp>(loc, i64Ty, wSlot.getResult()).getResult();
+
+    auto idxTy = rewriter.getIndexType();
+    auto h = rewriter.create<mlir::arith::IndexCastOp>(loc, idxTy, h64).getResult();
+    auto w = rewriter.create<mlir::arith::IndexCastOp>(loc, idxTy, w64).getResult();
+
+    auto flatTy = mlir::MemRefType::get({mlir::ShapedType::kDynamic}, i8Ty);
+
+    // UnrealizedConversionCastOp wants TypeRange + ValueRange
+    auto baseMemref =
+        rewriter.create<mlir::UnrealizedConversionCastOp>(loc, mlir::TypeRange{flatTy}, mlir::ValueRange{dataPtr})
+            .getResult(0);
+
+    auto c4 = rewriter.create<mlir::arith::ConstantIndexOp>(loc, 4);
+    auto rowStride = rewriter.create<mlir::arith::MulIOp>(loc, w, c4);
+
+    auto resultTy = mlir::MemRefType::get({mlir::ShapedType::kDynamic, mlir::ShapedType::kDynamic, 4}, i8Ty);
+
+    llvm::SmallVector<mlir::OpFoldResult> sizes{mlir::OpFoldResult(h), mlir::OpFoldResult(w), rewriter.getIndexAttr(4)};
+    llvm::SmallVector<mlir::OpFoldResult> strides{mlir::OpFoldResult(rowStride), rewriter.getIndexAttr(4),
+                                                  rewriter.getIndexAttr(1)};
+
+    auto result = rewriter.create<mlir::memref::ReinterpretCastOp>(loc, resultTy, baseMemref, rewriter.getIndexAttr(0),
+                                                                   sizes, strides);
+
+    rewriter.replaceOp(op, result.getResult());
     return mlir::success();
   }
 };
@@ -72,20 +117,28 @@ struct ShowImageToCall : public mlir::OpConversionPattern<ShowImageOp> {
 
   mlir::LogicalResult matchAndRewrite(ShowImageOp op, ShowImageOpAdaptor adaptor,
                                       mlir::ConversionPatternRewriter &rewriter) const override {
-
     auto module = op->getParentOfType<mlir::ModuleOp>();
     auto ctx = rewriter.getContext();
     auto loc = op.getLoc();
 
-    auto imageType = ImageType::get(ctx);
+    auto ptrType = mlir::LLVM::LLVMPointerType::get(ctx);
+    auto i32Type = rewriter.getI32Type();
 
-    auto func = ensureRuntimeFunc(module, "piccelerShowImage", {imageType}, {}, rewriter, loc);
-    llvm::SmallVector<mlir::Value, 1> args;
-    args.push_back(adaptor.getInput());
+    mlir::Value img = adaptor.getInput(); // memref<?x?x4xi8>
 
-    auto call = rewriter.create<mlir::func::CallOp>(loc, func, args);
+    auto ptrIdx = rewriter.create<mlir::memref::ExtractAlignedPointerAsIndexOp>(loc, img);
+    auto ptrI64 = rewriter.create<mlir::arith::IndexCastOp>(loc, rewriter.getI64Type(), ptrIdx);
+    auto dataPtr = rewriter.create<mlir::LLVM::IntToPtrOp>(loc, ptrType, ptrI64.getResult());
+
+    auto heightIdx = rewriter.create<mlir::memref::DimOp>(loc, img, 0);
+    auto widthIdx = rewriter.create<mlir::memref::DimOp>(loc, img, 1);
+    auto height32 = rewriter.create<mlir::arith::IndexCastOp>(loc, i32Type, heightIdx);
+    auto width32 = rewriter.create<mlir::arith::IndexCastOp>(loc, i32Type, widthIdx);
+
+    auto func = ensureRuntimeFunc(module, "piccelerShowImage", {ptrType, i32Type, i32Type}, {}, rewriter, loc);
+    auto call = rewriter.create<mlir::func::CallOp>(loc, func, mlir::ValueRange{dataPtr, width32, height32});
+
     rewriter.replaceOp(op, call.getResults());
-
     return mlir::success();
   }
 };
@@ -103,17 +156,27 @@ struct SaveImageToCall : public mlir::OpConversionPattern<SaveImageOp> {
     auto ctx = rewriter.getContext();
     auto loc = op.getLoc();
 
+    auto ptrType = mlir::LLVM::LLVMPointerType::get(ctx);
+    auto i32Type = rewriter.getI32Type();
     auto stringType = StringType::get(ctx);
-    auto imageType = ImageType::get(ctx);
 
-    auto func = ensureRuntimeFunc(module, "piccelerSaveImage", {imageType, stringType}, {}, rewriter, loc);
-    llvm::SmallVector<mlir::Value, 2> args;
-    args.push_back(adaptor.getInput());
-    args.push_back(adaptor.getFilename());
+    mlir::Value img = adaptor.getInput(); // memref<?x?x4xi8>
 
-    auto call = rewriter.create<mlir::func::CallOp>(loc, func, args);
+    auto ptrIdx = rewriter.create<mlir::memref::ExtractAlignedPointerAsIndexOp>(loc, img);
+    auto ptrI64 = rewriter.create<mlir::arith::IndexCastOp>(loc, rewriter.getI64Type(), ptrIdx);
+    auto dataPtr = rewriter.create<mlir::LLVM::IntToPtrOp>(loc, ptrType, ptrI64.getResult());
+
+    auto height32 =
+        rewriter.create<mlir::arith::IndexCastOp>(loc, i32Type, rewriter.create<mlir::memref::DimOp>(loc, img, 0));
+    auto width32 =
+        rewriter.create<mlir::arith::IndexCastOp>(loc, i32Type, rewriter.create<mlir::memref::DimOp>(loc, img, 1));
+
+    auto func =
+        ensureRuntimeFunc(module, "piccelerSaveImage", {ptrType, i32Type, i32Type, stringType}, {}, rewriter, loc);
+    auto call = rewriter.create<mlir::func::CallOp>(
+        loc, func, mlir::ValueRange{dataPtr, width32, height32, adaptor.getFilename()});
+
     rewriter.replaceOp(op, call.getResults());
-
     return mlir::success();
   }
 };
@@ -260,14 +323,25 @@ struct PiccelerOpsToFuncCallsPass : public impl::PiccelerOpsToFuncCallsBase<Picc
   void runOnOperation() override {
     mlir::ModuleOp module = getOperation();
 
+    mlir::TypeConverter typeConverter;
+    typeConverter.addConversion([](mlir::Type type) { return type; });
+    typeConverter.addConversion([](ImageType imageType) -> mlir::Type {
+      auto kDynamic = mlir::ShapedType::kDynamic;
+      return mlir::MemRefType::get({kDynamic, kDynamic, 4}, mlir::IntegerType::get(imageType.getContext(), 8));
+    });
+
     mlir::ConversionTarget target(getContext());
     target.addLegalOp<mlir::ModuleOp, StringConstOp>();
-    target.addLegalDialect<mlir::func::FuncDialect>();
+    target.addLegalDialect<mlir::func::FuncDialect, mlir::arith::ArithDialect, mlir::memref::MemRefDialect,
+                           mlir::BuiltinDialect, mlir::LLVM::LLVMDialect>();
     target.addIllegalOp<LoadImageOp, ShowImageOp, SaveImageOp, ReadNumberOp, ReadStringOp, PrintOp>();
+
+    target.markUnknownOpDynamicallyLegal([&](mlir::Operation *op) { return typeConverter.isLegal(op); });
 
     mlir::RewritePatternSet patterns(&getContext());
     patterns.add<LoadImageToCall, ShowImageToCall, SaveImageToCall, ReadNumberToCall, ReadStringToCall, PrintToCalls>(
-        &getContext());
+        typeConverter, &getContext());
+    patterns.add<GenericTypeUpdatePattern>(typeConverter, &getContext());
 
     if (mlir::failed(mlir::applyPartialConversion(module, target, std::move(patterns)))) {
       signalPassFailure();

--- a/src/picceler_ops_to_func_calls_pass.cpp
+++ b/src/picceler_ops_to_func_calls_pass.cpp
@@ -8,6 +8,8 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Conversion/LLVMCommon/MemRefBuilder.h"
+#include "mlir/Conversion/LLVMCommon/TypeConverter.h"
 
 #include "ops.h"
 #include "types.h"
@@ -43,6 +45,40 @@ mlir::func::FuncOp ensureRuntimeFunc(mlir::ModuleOp module, mlir::StringRef name
   return func;
 }
 
+/**
+ * @brief Builds a memref<?x?x4xi8> LLVM descriptor directly from a raw data pointer and
+ * dynamic height/width (both i64-typed, matching LLVMTypeConverter's default index type),
+ * emitting a single UnrealizedConversionCastOp from the LLVM struct to the memref type.
+ * This cast is a structural identity (LLVMTypeConverter converts memref<?x?x4xi8> to exactly
+ * this struct type), so it folds away cleanly under ReconcileUnrealizedCastsPass, unlike a
+ * cast straight from !llvm.ptr to memref.
+ */
+mlir::Value buildImageMemref(mlir::PatternRewriter &rewriter, mlir::Location loc, mlir::Value dataPtr,
+                             mlir::Value heightI64, mlir::Value widthI64) {
+  auto kDynamic = mlir::ShapedType::kDynamic;
+  auto targetMemRefType = mlir::MemRefType::get({kDynamic, kDynamic, 4}, rewriter.getIntegerType(8));
+
+  mlir::LLVMTypeConverter llvmTypeConverter(rewriter.getContext());
+  auto descTy = llvmTypeConverter.convertType(targetMemRefType);
+
+  mlir::MemRefDescriptor desc = mlir::MemRefDescriptor::poison(rewriter, loc, descTy);
+
+  auto c4 = rewriter.create<mlir::arith::ConstantIntOp>(loc, 4, 64).getResult();
+  auto rowStride = rewriter.create<mlir::arith::MulIOp>(loc, widthI64, c4).getResult();
+
+  desc.setAllocatedPtr(rewriter, loc, dataPtr);
+  desc.setAlignedPtr(rewriter, loc, dataPtr);
+  desc.setConstantOffset(rewriter, loc, 0);
+  desc.setSize(rewriter, loc, 0, heightI64);
+  desc.setSize(rewriter, loc, 1, widthI64);
+  desc.setConstantSize(rewriter, loc, 2, 4);
+  desc.setStride(rewriter, loc, 0, rowStride);
+  desc.setConstantStride(rewriter, loc, 1, 4);
+  desc.setConstantStride(rewriter, loc, 2, 1);
+
+  return rewriter.create<mlir::UnrealizedConversionCastOp>(loc, targetMemRefType, mlir::Value(desc)).getResult(0);
+}
+
 struct LoadImageToCall : public mlir::OpConversionPattern<LoadImageOp> {
   using mlir::OpConversionPattern<LoadImageOp>::OpConversionPattern;
 
@@ -52,7 +88,6 @@ struct LoadImageToCall : public mlir::OpConversionPattern<LoadImageOp> {
     auto loc = op.getLoc();
     auto *ctx = rewriter.getContext();
 
-    auto i8Ty = rewriter.getIntegerType(8);
     auto i64Ty = rewriter.getI64Type();
     auto ptrTy = mlir::LLVM::LLVMPointerType::get(ctx);
 
@@ -81,30 +116,9 @@ struct LoadImageToCall : public mlir::OpConversionPattern<LoadImageOp> {
     auto h64 = rewriter.create<mlir::LLVM::LoadOp>(loc, i64Ty, hSlot.getResult()).getResult();
     auto w64 = rewriter.create<mlir::LLVM::LoadOp>(loc, i64Ty, wSlot.getResult()).getResult();
 
-    auto idxTy = rewriter.getIndexType();
-    auto h = rewriter.create<mlir::arith::IndexCastOp>(loc, idxTy, h64).getResult();
-    auto w = rewriter.create<mlir::arith::IndexCastOp>(loc, idxTy, w64).getResult();
+    auto result = buildImageMemref(rewriter, loc, dataPtr, h64, w64);
 
-    auto flatTy = mlir::MemRefType::get({mlir::ShapedType::kDynamic}, i8Ty);
-
-    // UnrealizedConversionCastOp wants TypeRange + ValueRange
-    auto baseMemref =
-        rewriter.create<mlir::UnrealizedConversionCastOp>(loc, mlir::TypeRange{flatTy}, mlir::ValueRange{dataPtr})
-            .getResult(0);
-
-    auto c4 = rewriter.create<mlir::arith::ConstantIndexOp>(loc, 4);
-    auto rowStride = rewriter.create<mlir::arith::MulIOp>(loc, w, c4);
-
-    auto resultTy = mlir::MemRefType::get({mlir::ShapedType::kDynamic, mlir::ShapedType::kDynamic, 4}, i8Ty);
-
-    llvm::SmallVector<mlir::OpFoldResult> sizes{mlir::OpFoldResult(h), mlir::OpFoldResult(w), rewriter.getIndexAttr(4)};
-    llvm::SmallVector<mlir::OpFoldResult> strides{mlir::OpFoldResult(rowStride), rewriter.getIndexAttr(4),
-                                                  rewriter.getIndexAttr(1)};
-
-    auto result = rewriter.create<mlir::memref::ReinterpretCastOp>(loc, resultTy, baseMemref, rewriter.getIndexAttr(0),
-                                                                   sizes, strides);
-
-    rewriter.replaceOp(op, result.getResult());
+    rewriter.replaceOp(op, result);
     return mlir::success();
   }
 };

--- a/src/picceler_to_affine_pass.cpp
+++ b/src/picceler_to_affine_pass.cpp
@@ -17,59 +17,42 @@
 #include "ops.h"
 #include "types.h"
 #include "dialect.h"
-#include "image_access_helper.h"
 
 namespace picceler {
 
 struct BrightnessToAffine : mlir::OpConversionPattern<BrightnessOp> {
   using OpConversionPattern::OpConversionPattern;
-  // Implementation of the pattern to convert BrightnessOp to Affine dialect
+
   mlir::LogicalResult matchAndRewrite(BrightnessOp op, BrightnessOpAdaptor adaptor,
                                       mlir::ConversionPatternRewriter &rewriter) const override {
-
     mlir::Location loc = op.getLoc();
+    auto i8Type = rewriter.getI8Type();
 
     mlir::Value input = adaptor.getInput();
-    auto ptrType = mlir::LLVM::LLVMPointerType::get(getContext());
-    if (input.getType() != ptrType) {
-      input = rewriter.create<mlir::UnrealizedConversionCastOp>(loc, ptrType, input).getResult(0);
+    if (!mlir::isa<mlir::MemRefType>(input.getType())) {
+      op.emitOpError("expected input image to be a MemRefType");
+      return mlir::failure();
     }
 
-    ImageAccessHelper inputImage(input, rewriter, loc);
-    mlir::Value inputWidthI32 = inputImage.getWidth();
-    mlir::Value inputHeightI32 = inputImage.getHeight();
-    mlir::Value inputDataPtr = inputImage.getDataPtr();
+    mlir::Value inputHeight = rewriter.create<mlir::memref::DimOp>(loc, input, 0);
+    mlir::Value inputWidth = rewriter.create<mlir::memref::DimOp>(loc, input, 1);
 
-    auto createCall = rewriter.create<mlir::func::CallOp>(loc, ptrType, "piccelerCreateImage",
-                                                          mlir::ValueRange{inputWidthI32, inputHeightI32});
-    mlir::Value output = createCall.getResult(0);
-
-    ImageAccessHelper outputImage(output, rewriter, loc);
-    mlir::Value outputDataPtr = outputImage.getDataPtr();
-
-    mlir::Value width = rewriter.create<mlir::arith::IndexCastOp>(loc, rewriter.getIndexType(), inputWidthI32);
-    mlir::Value height = rewriter.create<mlir::arith::IndexCastOp>(loc, rewriter.getIndexType(), inputHeightI32);
+    auto kDynamic = mlir::ShapedType::kDynamic;
+    auto output = rewriter.create<mlir::memref::AllocOp>(loc, mlir::MemRefType::get({kDynamic, kDynamic, 4}, i8Type),
+                                                         mlir::ValueRange{inputHeight, inputWidth});
 
     auto ubMap = mlir::AffineMap::get(1, 0, rewriter.getAffineDimExpr(0), rewriter.getContext());
 
     auto rowLoop = rewriter.create<mlir::affine::AffineForOp>(loc, mlir::ValueRange{}, rewriter.getConstantAffineMap(0),
-                                                              height, ubMap, 1);
-
+                                                              inputHeight, ubMap, 1);
     rewriter.setInsertionPointToStart(rowLoop.getBody());
 
     auto colLoop = rewriter.create<mlir::affine::AffineForOp>(loc, mlir::ValueRange{}, rewriter.getConstantAffineMap(0),
-                                                              width, ubMap, 1);
-
+                                                              inputWidth, ubMap, 1);
     rewriter.setInsertionPointToStart(colLoop.getBody());
 
     mlir::Value pixelRowIndex = rowLoop.getInductionVar();
     mlir::Value pixelColIndex = colLoop.getInductionVar();
-
-    auto indexMap = mlir::AffineMap::get(
-        2, 1, (rewriter.getAffineDimExpr(0) * rewriter.getAffineSymbolExpr(0) + rewriter.getAffineDimExpr(1)) * 4);
-
-    mlir::Value pixelBaseIndex = rewriter.create<mlir::affine::AffineApplyOp>(
-        loc, indexMap, mlir::ValueRange{pixelRowIndex, pixelColIndex, width});
 
     mlir::Value amount = adaptor.getValue();
     mlir::Value amountI32 = rewriter.create<mlir::arith::TruncIOp>(loc, rewriter.getI32Type(), amount);
@@ -78,13 +61,10 @@ struct BrightnessToAffine : mlir::OpConversionPattern<BrightnessOp> {
     mlir::Value c255 = rewriter.create<mlir::arith::ConstantIntOp>(loc, 255, 32);
 
     auto processChannel = [&](Channel ch) {
-      mlir::Value cOffset = rewriter.create<mlir::arith::ConstantIndexOp>(loc, static_cast<int>(ch));
-      mlir::Value byteAddr = rewriter.create<mlir::arith::AddIOp>(loc, pixelBaseIndex, cOffset);
-      mlir::Value byteAddrI64 = rewriter.create<mlir::arith::IndexCastOp>(loc, rewriter.getI64Type(), byteAddr);
+      auto cOffset = rewriter.create<mlir::arith::ConstantIndexOp>(loc, static_cast<int>(ch));
 
-      auto inputBytePtr =
-          rewriter.create<mlir::LLVM::GEPOp>(loc, ptrType, rewriter.getI8Type(), inputDataPtr, byteAddrI64);
-      auto inputByte = rewriter.create<mlir::LLVM::LoadOp>(loc, rewriter.getI8Type(), inputBytePtr);
+      auto inputByte =
+          rewriter.create<mlir::memref::LoadOp>(loc, input, mlir::ValueRange{pixelRowIndex, pixelColIndex, cOffset});
 
       mlir::Value finalValue;
       if (ch != Channel::A) {
@@ -92,15 +72,13 @@ struct BrightnessToAffine : mlir::OpConversionPattern<BrightnessOp> {
         auto brightened = rewriter.create<mlir::arith::AddIOp>(loc, inputByteI32, amountI32);
         auto clampedLow = rewriter.create<mlir::arith::MinSIOp>(loc, brightened, c255);
         auto clampedHigh = rewriter.create<mlir::arith::MaxSIOp>(loc, clampedLow, c0);
-        finalValue = rewriter.create<mlir::arith::TruncIOp>(loc, rewriter.getI8Type(), clampedHigh);
-
+        finalValue = rewriter.create<mlir::arith::TruncIOp>(loc, i8Type, clampedHigh);
       } else {
         finalValue = inputByte;
       }
 
-      auto outputBytePtr =
-          rewriter.create<mlir::LLVM::GEPOp>(loc, ptrType, rewriter.getI8Type(), outputDataPtr, byteAddrI64);
-      rewriter.create<mlir::LLVM::StoreOp>(loc, finalValue, outputBytePtr);
+      rewriter.create<mlir::memref::StoreOp>(loc, finalValue, output,
+                                             mlir::ValueRange{pixelRowIndex, pixelColIndex, cOffset});
     };
 
     processChannel(Channel::R);
@@ -108,7 +86,7 @@ struct BrightnessToAffine : mlir::OpConversionPattern<BrightnessOp> {
     processChannel(Channel::B);
     processChannel(Channel::A);
 
-    // output
+    rewriter.setInsertionPointAfter(rowLoop);
     rewriter.replaceOp(op, output);
 
     return mlir::success();
@@ -120,61 +98,43 @@ struct InvertToAffine : mlir::OpConversionPattern<InvertOp> {
 
   mlir::LogicalResult matchAndRewrite(InvertOp op, InvertOpAdaptor adaptor,
                                       mlir::ConversionPatternRewriter &rewriter) const override {
-
     mlir::Location loc = op.getLoc();
+    auto i8Type = rewriter.getI8Type();
+    auto indexType = rewriter.getIndexType();
 
     mlir::Value input = adaptor.getInput();
-    auto ptrType = mlir::LLVM::LLVMPointerType::get(getContext());
-    if (input.getType() != ptrType) {
-      input = rewriter.create<mlir::UnrealizedConversionCastOp>(loc, ptrType, input).getResult(0);
+    if (!mlir::isa<mlir::MemRefType>(input.getType())) {
+      op.emitOpError("expected input image to be a MemRefType");
+      return mlir::failure();
     }
 
-    ImageAccessHelper inputImage(input, rewriter, loc);
-    mlir::Value inputWidthI32 = inputImage.getWidth();
-    mlir::Value inputHeightI32 = inputImage.getHeight();
-    mlir::Value inputDataPtr = inputImage.getDataPtr();
+    mlir::Value inputHeight = rewriter.create<mlir::memref::DimOp>(loc, input, 0);
+    mlir::Value inputWidth = rewriter.create<mlir::memref::DimOp>(loc, input, 1);
 
-    auto createCall = rewriter.create<mlir::func::CallOp>(loc, ptrType, "piccelerCreateImage",
-                                                          mlir::ValueRange{inputWidthI32, inputHeightI32});
-    mlir::Value output = createCall.getResult(0);
-
-    ImageAccessHelper outputImage(output, rewriter, loc);
-    mlir::Value outputDataPtr = outputImage.getDataPtr();
-
-    mlir::Value width = rewriter.create<mlir::arith::IndexCastOp>(loc, rewriter.getIndexType(), inputWidthI32);
-    mlir::Value height = rewriter.create<mlir::arith::IndexCastOp>(loc, rewriter.getIndexType(), inputHeightI32);
+    auto kDynamic = mlir::ShapedType::kDynamic;
+    auto output = rewriter.create<mlir::memref::AllocOp>(loc, mlir::MemRefType::get({kDynamic, kDynamic, 4}, i8Type),
+                                                         mlir::ValueRange{inputHeight, inputWidth});
 
     auto ubMap = mlir::AffineMap::get(1, 0, rewriter.getAffineDimExpr(0), rewriter.getContext());
 
     auto rowLoop = rewriter.create<mlir::affine::AffineForOp>(loc, mlir::ValueRange{}, rewriter.getConstantAffineMap(0),
-                                                              height, ubMap, 1);
-
+                                                              inputHeight, ubMap, 1);
     rewriter.setInsertionPointToStart(rowLoop.getBody());
 
     auto colLoop = rewriter.create<mlir::affine::AffineForOp>(loc, mlir::ValueRange{}, rewriter.getConstantAffineMap(0),
-                                                              width, ubMap, 1);
-
+                                                              inputWidth, ubMap, 1);
     rewriter.setInsertionPointToStart(colLoop.getBody());
 
     mlir::Value pixelRowIndex = rowLoop.getInductionVar();
     mlir::Value pixelColIndex = colLoop.getInductionVar();
 
-    auto indexMap = mlir::AffineMap::get(
-        2, 1, (rewriter.getAffineDimExpr(0) * rewriter.getAffineSymbolExpr(0) + rewriter.getAffineDimExpr(1)) * 4);
-
-    mlir::Value pixelBaseIndex = rewriter.create<mlir::affine::AffineApplyOp>(
-        loc, indexMap, mlir::ValueRange{pixelRowIndex, pixelColIndex, width});
-
-    auto c255 = rewriter.create<mlir::arith::ConstantIntOp>(loc, rewriter.getI8Type(), 255);
+    auto c255 = rewriter.create<mlir::arith::ConstantIntOp>(loc, i8Type, 255);
 
     auto processChannel = [&](Channel ch) {
-      mlir::Value cOffset = rewriter.create<mlir::arith::ConstantIndexOp>(loc, static_cast<int>(ch));
-      mlir::Value byteAddr = rewriter.create<mlir::arith::AddIOp>(loc, pixelBaseIndex, cOffset);
-      mlir::Value byteAddrI64 = rewriter.create<mlir::arith::IndexCastOp>(loc, rewriter.getI64Type(), byteAddr);
+      auto cOffset = rewriter.create<mlir::arith::ConstantIndexOp>(loc, static_cast<int>(ch));
 
-      auto inputBytePtr =
-          rewriter.create<mlir::LLVM::GEPOp>(loc, ptrType, rewriter.getI8Type(), inputDataPtr, byteAddrI64);
-      auto inputByte = rewriter.create<mlir::LLVM::LoadOp>(loc, rewriter.getI8Type(), inputBytePtr);
+      auto inputByte =
+          rewriter.create<mlir::memref::LoadOp>(loc, input, mlir::ValueRange{pixelRowIndex, pixelColIndex, cOffset});
 
       mlir::Value finalValue;
       if (ch != Channel::A) {
@@ -183,9 +143,8 @@ struct InvertToAffine : mlir::OpConversionPattern<InvertOp> {
         finalValue = inputByte;
       }
 
-      auto outputBytePtr =
-          rewriter.create<mlir::LLVM::GEPOp>(loc, ptrType, rewriter.getI8Type(), outputDataPtr, byteAddrI64);
-      rewriter.create<mlir::LLVM::StoreOp>(loc, finalValue, outputBytePtr);
+      rewriter.create<mlir::memref::StoreOp>(loc, finalValue, output,
+                                             mlir::ValueRange{pixelRowIndex, pixelColIndex, cOffset});
     };
 
     processChannel(Channel::R);
@@ -193,31 +152,28 @@ struct InvertToAffine : mlir::OpConversionPattern<InvertOp> {
     processChannel(Channel::B);
     processChannel(Channel::A);
 
+    rewriter.setInsertionPointAfter(rowLoop);
     rewriter.replaceOp(op, output);
     return mlir::success();
   }
 };
-
 struct RotateToAffine : mlir::OpConversionPattern<RotateOp> {
   using OpConversionPattern::OpConversionPattern;
 
   mlir::LogicalResult matchAndRewrite(RotateOp op, RotateOpAdaptor adaptor,
                                       mlir::ConversionPatternRewriter &rewriter) const override {
     mlir::Location loc = op.getLoc();
-    auto ptrType = mlir::LLVM::LLVMPointerType::get(getContext());
     auto i8Type = rewriter.getI8Type();
-    auto i64Type = rewriter.getI64Type();
     auto indexType = rewriter.getIndexType();
 
     mlir::Value input = adaptor.getInput();
-    if (input.getType() != ptrType) {
-      input = rewriter.create<mlir::UnrealizedConversionCastOp>(loc, ptrType, input).getResult(0);
+    if (!mlir::isa<mlir::MemRefType>(input.getType())) {
+      op.emitOpError("expected input image to be a MemRefType");
+      return mlir::failure();
     }
 
-    ImageAccessHelper inputImage(input, rewriter, loc);
-    mlir::Value inputWidthI32 = inputImage.getWidth();
-    mlir::Value inputHeightI32 = inputImage.getHeight();
-    mlir::Value inputDataPtr = inputImage.getDataPtr();
+    mlir::Value inputHeight = rewriter.create<mlir::memref::DimOp>(loc, input, 0);
+    mlir::Value inputWidth = rewriter.create<mlir::memref::DimOp>(loc, input, 1);
 
     auto c90I64 = rewriter.create<mlir::arith::ConstantIntOp>(loc, 90, 64);
     auto c180I64 = rewriter.create<mlir::arith::ConstantIntOp>(loc, 180, 64);
@@ -245,20 +201,12 @@ struct RotateToAffine : mlir::OpConversionPattern<RotateOp> {
         rewriter.create<mlir::arith::CmpIOp>(loc, mlir::arith::CmpIPredicate::eq, normalizedAngle, c270I64);
     mlir::Value is90Or270 = rewriter.create<mlir::arith::OrIOp>(loc, is90, is270);
 
-    mlir::Value outputWidthI32 = rewriter.create<mlir::arith::SelectOp>(loc, is90Or270, inputHeightI32, inputWidthI32);
-    mlir::Value outputHeightI32 = rewriter.create<mlir::arith::SelectOp>(loc, is90Or270, inputWidthI32, inputHeightI32);
+    mlir::Value outputHeight = rewriter.create<mlir::arith::SelectOp>(loc, is90Or270, inputWidth, inputHeight);
+    mlir::Value outputWidth = rewriter.create<mlir::arith::SelectOp>(loc, is90Or270, inputHeight, inputWidth);
 
-    auto createCall = rewriter.create<mlir::func::CallOp>(loc, ptrType, "piccelerCreateImage",
-                                                          mlir::ValueRange{outputWidthI32, outputHeightI32});
-    mlir::Value output = createCall.getResult(0);
-
-    ImageAccessHelper outputImage(output, rewriter, loc);
-    mlir::Value outputDataPtr = outputImage.getDataPtr();
-
-    mlir::Value inputWidth = rewriter.create<mlir::arith::IndexCastOp>(loc, indexType, inputWidthI32);
-    mlir::Value inputHeight = rewriter.create<mlir::arith::IndexCastOp>(loc, indexType, inputHeightI32);
-    mlir::Value outputWidth = rewriter.create<mlir::arith::IndexCastOp>(loc, indexType, outputWidthI32);
-    mlir::Value outputHeight = rewriter.create<mlir::arith::IndexCastOp>(loc, indexType, outputHeightI32);
+    auto kDynamic = mlir::ShapedType::kDynamic;
+    auto output = rewriter.create<mlir::memref::AllocOp>(loc, mlir::MemRefType::get({kDynamic, kDynamic, 4}, i8Type),
+                                                         mlir::ValueRange{outputHeight, outputWidth});
 
     auto ubMap = mlir::AffineMap::get(1, 0, rewriter.getAffineDimExpr(0), rewriter.getContext());
 
@@ -294,28 +242,13 @@ struct RotateToAffine : mlir::OpConversionPattern<RotateOp> {
     srcRow = rewriter.create<mlir::arith::SelectOp>(loc, is270, srcRowFor270DegRotation, srcRow);
     srcCol = rewriter.create<mlir::arith::SelectOp>(loc, is270, srcColFor270DegRotation, srcCol);
 
-    auto indexMap = mlir::AffineMap::get(
-        2, 1, (rewriter.getAffineDimExpr(0) * rewriter.getAffineSymbolExpr(0) + rewriter.getAffineDimExpr(1)) * 4);
-
-    mlir::Value dstPixelBaseIndex = rewriter.create<mlir::affine::AffineApplyOp>(
-        loc, indexMap, mlir::ValueRange{pixelRowIndex, pixelColIndex, outputWidth});
-    mlir::Value srcPixelBaseIndex =
-        rewriter.create<mlir::affine::AffineApplyOp>(loc, indexMap, mlir::ValueRange{srcRow, srcCol, inputWidth});
-
     auto copyChannel = [&](Channel ch) {
-      auto srcOffset = rewriter.create<mlir::arith::ConstantIndexOp>(loc, static_cast<int>(ch));
-      auto srcAddr = rewriter.create<mlir::arith::AddIOp>(loc, srcPixelBaseIndex, srcOffset);
-      auto srcAddrI64 = rewriter.create<mlir::arith::IndexCastOp>(loc, i64Type, srcAddr);
-      auto srcPtr =
-          rewriter.create<mlir::LLVM::GEPOp>(loc, ptrType, i8Type, inputDataPtr, mlir::ValueRange{srcAddrI64});
-      auto srcVal = rewriter.create<mlir::LLVM::LoadOp>(loc, i8Type, srcPtr);
+      auto cOffset = rewriter.create<mlir::arith::ConstantIndexOp>(loc, static_cast<int>(ch));
 
-      auto dstOffset = rewriter.create<mlir::arith::ConstantIndexOp>(loc, static_cast<int>(ch));
-      auto dstAddr = rewriter.create<mlir::arith::AddIOp>(loc, dstPixelBaseIndex, dstOffset);
-      auto dstAddrI64 = rewriter.create<mlir::arith::IndexCastOp>(loc, i64Type, dstAddr);
-      auto dstPtr =
-          rewriter.create<mlir::LLVM::GEPOp>(loc, ptrType, i8Type, outputDataPtr, mlir::ValueRange{dstAddrI64});
-      rewriter.create<mlir::LLVM::StoreOp>(loc, srcVal, dstPtr);
+      auto srcVal = rewriter.create<mlir::memref::LoadOp>(loc, input, mlir::ValueRange{srcRow, srcCol, cOffset});
+
+      rewriter.create<mlir::memref::StoreOp>(loc, srcVal, output,
+                                             mlir::ValueRange{pixelRowIndex, pixelColIndex, cOffset});
     };
 
     copyChannel(Channel::R);
@@ -342,11 +275,13 @@ struct NeighbourhoodOpsToAffine : mlir::OpInterfaceConversionPattern<Neighbourho
       return mlir::failure();
     }
 
-    auto img = operands[0];
-    mlir::Value kernelOperand;
-    if (operands.size() > 1) {
-      kernelOperand = operands[1];
+    mlir::Value input = operands[0];
+    if (!mlir::isa<mlir::MemRefType>(input.getType())) {
+      rawOp->emitOpError("expected input image to be a MemRefType");
+      return mlir::failure();
     }
+
+    mlir::Value kernelOperand = (operands.size() > 1) ? operands[1] : nullptr;
 
     auto neighborhoodSizeResult = op.getNeighborhoodSize(rewriter, loc, operands);
     if (!neighborhoodSizeResult) {
@@ -360,30 +295,15 @@ struct NeighbourhoodOpsToAffine : mlir::OpInterfaceConversionPattern<Neighbourho
     auto indexType = rewriter.getIndexType();
     auto i8Type = rewriter.getI8Type();
     auto f64Type = rewriter.getF64Type();
-    auto i64Type = rewriter.getI64Type();
 
-    mlir::Value input = img;
-    if (input.getType() != ptrType) {
-      input = rewriter.create<mlir::UnrealizedConversionCastOp>(loc, ptrType, input).getResult(0);
-    }
+    mlir::Value inputHeight = rewriter.create<mlir::memref::DimOp>(loc, input, 0);
+    mlir::Value inputWidth = rewriter.create<mlir::memref::DimOp>(loc, input, 1);
 
-    ImageAccessHelper inputImage(input, rewriter, loc);
-    mlir::Value inputWidthI32 = inputImage.getWidth();
-    mlir::Value inputHeightI32 = inputImage.getHeight();
-    mlir::Value inputDataPtr = inputImage.getDataPtr();
-
-    auto createCall = rewriter.create<mlir::func::CallOp>(loc, ptrType, "piccelerCreateImage",
-                                                          mlir::ValueRange{inputWidthI32, inputHeightI32});
-    mlir::Value output = createCall.getResult(0);
-
-    ImageAccessHelper outputImage(output, rewriter, loc);
-    mlir::Value outputDataPtr = outputImage.getDataPtr();
-
-    mlir::Value width = rewriter.create<mlir::arith::IndexCastOp>(loc, indexType, inputWidthI32);
-    mlir::Value height = rewriter.create<mlir::arith::IndexCastOp>(loc, indexType, inputHeightI32);
+    auto kDynamic = mlir::ShapedType::kDynamic;
+    auto output = rewriter.create<mlir::memref::AllocOp>(loc, mlir::MemRefType::get({kDynamic, kDynamic, 4}, i8Type),
+                                                         mlir::ValueRange{inputHeight, inputWidth});
 
     mlir::Value c2 = createIntConstant(rewriter, loc, 2);
-
     mlir::Value neighborhoodRowRadius = rewriter.create<mlir::arith::DivSIOp>(loc, neighborhoodRows, c2);
     mlir::Value neighborhoodColRadius = rewriter.create<mlir::arith::DivSIOp>(loc, neighborhoodCols, c2);
 
@@ -402,23 +322,17 @@ struct NeighbourhoodOpsToAffine : mlir::OpInterfaceConversionPattern<Neighbourho
     auto sumB = rewriter.create<mlir::LLVM::AllocaOp>(loc, ptrType, f64Type, oneConstant);
 
     auto rowLoop = rewriter.create<mlir::affine::AffineForOp>(
-        loc, mlir::ValueRange{}, rewriter.getConstantAffineMap(0), height,
+        loc, mlir::ValueRange{}, rewriter.getConstantAffineMap(0), inputHeight,
         mlir::AffineMap::get(1, 0, rewriter.getAffineDimExpr(0), rewriter.getContext()), 1);
     rewriter.setInsertionPointToStart(rowLoop.getBody());
 
     auto colLoop = rewriter.create<mlir::affine::AffineForOp>(
-        loc, mlir::ValueRange{}, rewriter.getConstantAffineMap(0), width,
+        loc, mlir::ValueRange{}, rewriter.getConstantAffineMap(0), inputWidth,
         mlir::AffineMap::get(1, 0, rewriter.getAffineDimExpr(0), rewriter.getContext()), 1);
     rewriter.setInsertionPointToStart(colLoop.getBody());
 
     mlir::Value pixelRowIndex = rowLoop.getInductionVar();
     mlir::Value pixelColIndex = colLoop.getInductionVar();
-
-    auto indexMap = mlir::AffineMap::get(
-        2, 1, (rewriter.getAffineDimExpr(0) * rewriter.getAffineSymbolExpr(0) + rewriter.getAffineDimExpr(1)) * 4);
-
-    mlir::Value pixelBaseIndex = rewriter.create<mlir::affine::AffineApplyOp>(
-        loc, indexMap, mlir::ValueRange{pixelRowIndex, pixelColIndex, width});
 
     mlir::Value initAcc = op.initializeAccumulator(rewriter, loc);
     rewriter.create<mlir::LLVM::StoreOp>(loc, initAcc, sumR);
@@ -447,9 +361,9 @@ struct NeighbourhoodOpsToAffine : mlir::OpInterfaceConversionPattern<Neighbourho
         loc, coordMap, mlir::ValueRange{pixelColIndex, kColIndex, neighborhoodColRadiusIdx});
 
     auto rowLow = rewriter.create<mlir::arith::CmpIOp>(loc, mlir::arith::CmpIPredicate::sge, sampleRow, zeroIndex);
-    auto rowHigh = rewriter.create<mlir::arith::CmpIOp>(loc, mlir::arith::CmpIPredicate::slt, sampleRow, height);
+    auto rowHigh = rewriter.create<mlir::arith::CmpIOp>(loc, mlir::arith::CmpIPredicate::slt, sampleRow, inputHeight);
     auto colLow = rewriter.create<mlir::arith::CmpIOp>(loc, mlir::arith::CmpIPredicate::sge, sampleCol, zeroIndex);
-    auto colHigh = rewriter.create<mlir::arith::CmpIOp>(loc, mlir::arith::CmpIPredicate::slt, sampleCol, width);
+    auto colHigh = rewriter.create<mlir::arith::CmpIOp>(loc, mlir::arith::CmpIPredicate::slt, sampleCol, inputWidth);
 
     auto rowValid = rewriter.create<mlir::arith::AndIOp>(loc, rowLow, rowHigh);
     auto colValid = rewriter.create<mlir::arith::AndIOp>(loc, colLow, colHigh);
@@ -458,9 +372,6 @@ struct NeighbourhoodOpsToAffine : mlir::OpInterfaceConversionPattern<Neighbourho
     auto ifOp = rewriter.create<mlir::scf::IfOp>(loc, isValid.getResult(), false);
     rewriter.setInsertionPointToStart(ifOp.thenBlock());
 
-    mlir::Value sampleBaseIndex =
-        rewriter.create<mlir::affine::AffineApplyOp>(loc, indexMap, mlir::ValueRange{sampleRow, sampleCol, width});
-
     mlir::Value kernelWeight = rewriter.create<mlir::arith::ConstantFloatOp>(loc, f64Type, llvm::APFloat(1.0));
     if (kernelOperand && mlir::isa<mlir::MemRefType>(kernelOperand.getType())) {
       kernelWeight = rewriter.create<mlir::memref::LoadOp>(loc, kernelOperand, mlir::ValueRange{kRowIndex, kColIndex});
@@ -468,12 +379,8 @@ struct NeighbourhoodOpsToAffine : mlir::OpInterfaceConversionPattern<Neighbourho
 
     auto accumulateChannel = [&](Channel ch, mlir::Value sumAlloca) {
       auto cOffset = rewriter.create<mlir::arith::ConstantIndexOp>(loc, static_cast<int>(ch));
-      auto byteAddr = rewriter.create<mlir::arith::AddIOp>(loc, sampleBaseIndex, cOffset);
-      auto byteAddrI64 = rewriter.create<mlir::arith::IndexCastOp>(loc, i64Type, byteAddr);
-
-      auto pixelPtr =
-          rewriter.create<mlir::LLVM::GEPOp>(loc, ptrType, i8Type, inputDataPtr, mlir::ValueRange{byteAddrI64});
-      auto pixelByte = rewriter.create<mlir::LLVM::LoadOp>(loc, i8Type, pixelPtr);
+      auto pixelByte =
+          rewriter.create<mlir::memref::LoadOp>(loc, input, mlir::ValueRange{sampleRow, sampleCol, cOffset});
       auto pixelAsF64 = rewriter.create<mlir::arith::UIToFPOp>(loc, f64Type, pixelByte);
 
       auto currentAcc = rewriter.create<mlir::LLVM::LoadOp>(loc, f64Type, sumAlloca);
@@ -498,11 +405,8 @@ struct NeighbourhoodOpsToAffine : mlir::OpInterfaceConversionPattern<Neighbourho
       auto byteVal = rewriter.create<mlir::arith::FPToUIOp>(loc, i8Type, clampedHigh);
 
       auto cOffset = rewriter.create<mlir::arith::ConstantIndexOp>(loc, static_cast<int>(ch));
-      auto outAddr = rewriter.create<mlir::arith::AddIOp>(loc, pixelBaseIndex, cOffset);
-      auto outAddrI64 = rewriter.create<mlir::arith::IndexCastOp>(loc, i64Type, outAddr);
-      auto outPtr =
-          rewriter.create<mlir::LLVM::GEPOp>(loc, ptrType, i8Type, outputDataPtr, mlir::ValueRange{outAddrI64});
-      rewriter.create<mlir::LLVM::StoreOp>(loc, byteVal, outPtr);
+      rewriter.create<mlir::memref::StoreOp>(loc, byteVal, output,
+                                             mlir::ValueRange{pixelRowIndex, pixelColIndex, cOffset});
     };
 
     finalizeChannel(Channel::R, sumR);
@@ -510,14 +414,9 @@ struct NeighbourhoodOpsToAffine : mlir::OpInterfaceConversionPattern<Neighbourho
     finalizeChannel(Channel::B, sumB);
 
     auto c3 = rewriter.create<mlir::arith::ConstantIndexOp>(loc, 3);
-    auto alphaAddr = rewriter.create<mlir::arith::AddIOp>(loc, pixelBaseIndex, c3);
-    auto alphaAddrI64 = rewriter.create<mlir::arith::IndexCastOp>(loc, i64Type, alphaAddr);
-    auto inputAlphaPtr =
-        rewriter.create<mlir::LLVM::GEPOp>(loc, ptrType, i8Type, inputDataPtr, mlir::ValueRange{alphaAddrI64});
-    auto alphaVal = rewriter.create<mlir::LLVM::LoadOp>(loc, i8Type, inputAlphaPtr);
-    auto outputAlphaPtr =
-        rewriter.create<mlir::LLVM::GEPOp>(loc, ptrType, i8Type, outputDataPtr, mlir::ValueRange{alphaAddrI64});
-    rewriter.create<mlir::LLVM::StoreOp>(loc, alphaVal, outputAlphaPtr);
+    auto alphaVal =
+        rewriter.create<mlir::memref::LoadOp>(loc, input, mlir::ValueRange{pixelRowIndex, pixelColIndex, c3});
+    rewriter.create<mlir::memref::StoreOp>(loc, alphaVal, output, mlir::ValueRange{pixelRowIndex, pixelColIndex, c3});
 
     rewriter.setInsertionPointAfter(rowLoop);
     rewriter.replaceOp(rawOp, output);
@@ -533,97 +432,68 @@ struct ElementWiseBinaryOpToAffine : mlir::OpInterfaceConversionPattern<ElementW
     auto *rawOp = op.getOperation();
     mlir::Location loc = rawOp->getLoc();
 
-    auto ptrType = mlir::LLVM::LLVMPointerType::get(getContext());
-    auto i8Type = rewriter.getI8Type();
-    auto i64Type = rewriter.getI64Type();
-    auto indexType = rewriter.getIndexType();
+    if (operands.size() < 2) {
+      rawOp->emitOpError("expected at least two operands");
+      return mlir::failure();
+    }
 
     auto lhsImage = operands[0];
     auto rhsImage = operands[1];
 
-    mlir::Value lhsInput = lhsImage;
-    if (lhsInput.getType() != ptrType) {
-      lhsInput = rewriter.create<mlir::UnrealizedConversionCastOp>(loc, ptrType, lhsInput).getResult(0);
+    if (!mlir::isa<mlir::MemRefType>(lhsImage.getType()) || !mlir::isa<mlir::MemRefType>(rhsImage.getType())) {
+      rawOp->emitOpError("expected input images to be MemRefTypes");
+      return mlir::failure();
     }
 
-    mlir::Value rhsInput = rhsImage;
-    if (rhsInput.getType() != ptrType) {
-      rhsInput = rewriter.create<mlir::UnrealizedConversionCastOp>(loc, ptrType, rhsInput).getResult(0);
-    }
+    auto i8Type = rewriter.getI8Type();
+    auto indexType = rewriter.getIndexType();
 
-    ImageAccessHelper lhsInputImage(lhsInput, rewriter, loc);
-    mlir::Value lhsWidthI32 = lhsInputImage.getWidth();
-    mlir::Value lhsHeightI32 = lhsInputImage.getHeight();
-    mlir::Value lhsDataPtr = lhsInputImage.getDataPtr();
+    mlir::Value lhsHeight = rewriter.create<mlir::memref::DimOp>(loc, lhsImage, 0);
+    mlir::Value lhsWidth = rewriter.create<mlir::memref::DimOp>(loc, lhsImage, 1);
 
-    ImageAccessHelper rhsInputImage(rhsInput, rewriter, loc);
-    mlir::Value rhsWidthI32 = rhsInputImage.getWidth();
-    mlir::Value rhsHeightI32 = rhsInputImage.getHeight();
-    mlir::Value rhsDataPtr = rhsInputImage.getDataPtr();
+    mlir::Value rhsHeight = rewriter.create<mlir::memref::DimOp>(loc, rhsImage, 0);
+    mlir::Value rhsWidth = rewriter.create<mlir::memref::DimOp>(loc, rhsImage, 1);
 
-    // compare dimensions and abort if they don't match
-    auto widthMismatch =
-        rewriter.create<mlir::arith::CmpIOp>(loc, mlir::arith::CmpIPredicate::ne, lhsWidthI32, rhsWidthI32);
+    // Compare dimensions and abort if they don't match
+    auto widthMismatch = rewriter.create<mlir::arith::CmpIOp>(loc, mlir::arith::CmpIPredicate::ne, lhsWidth, rhsWidth);
     auto heightMismatch =
-        rewriter.create<mlir::arith::CmpIOp>(loc, mlir::arith::CmpIPredicate::ne, lhsHeightI32, rhsHeightI32);
+        rewriter.create<mlir::arith::CmpIOp>(loc, mlir::arith::CmpIPredicate::ne, lhsHeight, rhsHeight);
     auto dimMismatch = rewriter.create<mlir::arith::OrIOp>(loc, widthMismatch, heightMismatch);
     auto ifDimMismatch = rewriter.create<mlir::scf::IfOp>(loc, dimMismatch.getResult(), false);
     rewriter.setInsertionPointToStart(ifDimMismatch.thenBlock());
-    // abort if dimensions don't match
     rewriter.create<mlir::func::CallOp>(loc, "abort", mlir::TypeRange{}, mlir::ValueRange{});
 
     rewriter.setInsertionPointAfter(ifDimMismatch);
 
-    auto createCall = rewriter.create<mlir::func::CallOp>(loc, ptrType, "piccelerCreateImage",
-                                                          mlir::ValueRange{lhsWidthI32, lhsHeightI32});
-    mlir::Value output = createCall.getResult(0);
-    ImageAccessHelper outputImage(output, rewriter, loc);
-    mlir::Value outputDataPtr = outputImage.getDataPtr();
-
-    mlir::Value width = rewriter.create<mlir::arith::IndexCastOp>(loc, indexType, lhsWidthI32);
-    mlir::Value height = rewriter.create<mlir::arith::IndexCastOp>(loc, indexType, lhsHeightI32);
+    auto kDynamic = mlir::ShapedType::kDynamic;
+    auto output = rewriter.create<mlir::memref::AllocOp>(loc, mlir::MemRefType::get({kDynamic, kDynamic, 4}, i8Type),
+                                                         mlir::ValueRange{lhsHeight, lhsWidth});
 
     auto ubMap = mlir::AffineMap::get(1, 0, rewriter.getAffineDimExpr(0), rewriter.getContext());
 
     auto rowLoop = rewriter.create<mlir::affine::AffineForOp>(loc, mlir::ValueRange{}, rewriter.getConstantAffineMap(0),
-                                                              height, ubMap, 1);
-
+                                                              lhsHeight, ubMap, 1);
     rewriter.setInsertionPointToStart(rowLoop.getBody());
 
     auto colLoop = rewriter.create<mlir::affine::AffineForOp>(loc, mlir::ValueRange{}, rewriter.getConstantAffineMap(0),
-                                                              width, ubMap, 1);
-
+                                                              lhsWidth, ubMap, 1);
     rewriter.setInsertionPointToStart(colLoop.getBody());
 
     mlir::Value pixelRowIndex = rowLoop.getInductionVar();
     mlir::Value pixelColIndex = colLoop.getInductionVar();
 
-    auto indexMap = mlir::AffineMap::get(
-        2, 1, (rewriter.getAffineDimExpr(0) * rewriter.getAffineSymbolExpr(0) + rewriter.getAffineDimExpr(1)) * 4);
-
-    auto pixelBaseIndex = rewriter.create<mlir::affine::AffineApplyOp>(
-        loc, indexMap, mlir::ValueRange{pixelRowIndex, pixelColIndex, width});
-
     auto processChannel = [&](Channel ch) {
       auto cOffset = rewriter.create<mlir::arith::ConstantIndexOp>(loc, static_cast<int>(ch));
-      auto byteAddr = rewriter.create<mlir::arith::AddIOp>(loc, pixelBaseIndex, cOffset);
-      auto byteAddrI64 = rewriter.create<mlir::arith::IndexCastOp>(loc, i64Type, byteAddr);
 
-      auto lhsBytePtr =
-          rewriter.create<mlir::LLVM::GEPOp>(loc, ptrType, i8Type, lhsDataPtr, mlir::ValueRange{byteAddrI64});
-      auto lhsByte = rewriter.create<mlir::LLVM::LoadOp>(loc, i8Type, lhsBytePtr);
-
-      auto rhsBytePtr =
-          rewriter.create<mlir::LLVM::GEPOp>(loc, ptrType, i8Type, rhsDataPtr, mlir::ValueRange{byteAddrI64});
-      auto rhsByte = rewriter.create<mlir::LLVM::LoadOp>(loc, i8Type, rhsBytePtr);
+      auto lhsByte =
+          rewriter.create<mlir::memref::LoadOp>(loc, lhsImage, mlir::ValueRange{pixelRowIndex, pixelColIndex, cOffset});
+      auto rhsByte =
+          rewriter.create<mlir::memref::LoadOp>(loc, rhsImage, mlir::ValueRange{pixelRowIndex, pixelColIndex, cOffset});
 
       auto resultByte = op.transformPixels(rewriter, loc, lhsByte, rhsByte, ch);
 
-      auto outAddr = rewriter.create<mlir::arith::AddIOp>(loc, pixelBaseIndex, cOffset);
-      auto outAddrI64 = rewriter.create<mlir::arith::IndexCastOp>(loc, i64Type, outAddr);
-      auto outPtr =
-          rewriter.create<mlir::LLVM::GEPOp>(loc, ptrType, i8Type, outputDataPtr, mlir::ValueRange{outAddrI64});
-      rewriter.create<mlir::LLVM::StoreOp>(loc, resultByte, outPtr);
+      rewriter.create<mlir::memref::StoreOp>(loc, resultByte, output,
+                                             mlir::ValueRange{pixelRowIndex, pixelColIndex, cOffset});
     };
 
     processChannel(Channel::R);
@@ -644,43 +514,33 @@ struct CropToAffine : mlir::OpConversionPattern<CropOp> {
   mlir::LogicalResult matchAndRewrite(CropOp op, CropOpAdaptor adaptor,
                                       mlir::ConversionPatternRewriter &rewriter) const override {
     mlir::Location loc = op.getLoc();
-    auto ptrType = mlir::LLVM::LLVMPointerType::get(getContext());
     auto i8Type = rewriter.getI8Type();
-    auto i64Type = rewriter.getI64Type();
     auto indexType = rewriter.getIndexType();
 
     mlir::Value input = adaptor.getInput();
-    if (input.getType() != ptrType) {
-      input = rewriter.create<mlir::UnrealizedConversionCastOp>(loc, ptrType, input).getResult(0);
+    if (!mlir::isa<mlir::MemRefType>(input.getType())) {
+      op.emitOpError("expected input image to be a MemRefType");
+      return mlir::failure();
     }
 
-    ImageAccessHelper inputImage(input, rewriter, loc);
-    mlir::Value inputWidthI32 = inputImage.getWidth();
-    mlir::Value inputHeightI32 = inputImage.getHeight();
-    mlir::Value inputDataPtr = inputImage.getDataPtr();
+    mlir::Value inputHeight = rewriter.create<mlir::memref::DimOp>(loc, input, 0);
+    mlir::Value inputWidth = rewriter.create<mlir::memref::DimOp>(loc, input, 1);
+    (void)inputWidth;
+    (void)inputHeight;
 
     mlir::Value xI32 = adaptor.getX();
     mlir::Value yI32 = adaptor.getY();
     mlir::Value cropWI32 = rewriter.create<mlir::arith::TruncIOp>(loc, rewriter.getI32Type(), adaptor.getWidth());
     mlir::Value cropHI32 = rewriter.create<mlir::arith::TruncIOp>(loc, rewriter.getI32Type(), adaptor.getHeight());
 
-    // create output image with crop size
-    auto createCall =
-        rewriter.create<mlir::func::CallOp>(loc, ptrType, "piccelerCreateImage", mlir::ValueRange{cropWI32, cropHI32});
-    mlir::Value output = createCall.getResult(0);
-
-    ImageAccessHelper outputImage(output, rewriter, loc);
-    mlir::Value outputDataPtr = outputImage.getDataPtr();
-
-    mlir::Value inputWidth = rewriter.create<mlir::arith::IndexCastOp>(loc, indexType, inputWidthI32);
-    mlir::Value inputHeight = rewriter.create<mlir::arith::IndexCastOp>(loc, indexType, inputHeightI32);
-    (void)inputWidth;
-    (void)inputHeight;
-
     mlir::Value xIndex = rewriter.create<mlir::arith::IndexCastOp>(loc, indexType, xI32);
     mlir::Value yIndex = rewriter.create<mlir::arith::IndexCastOp>(loc, indexType, yI32);
     mlir::Value cropW = rewriter.create<mlir::arith::IndexCastOp>(loc, indexType, cropWI32);
     mlir::Value cropH = rewriter.create<mlir::arith::IndexCastOp>(loc, indexType, cropHI32);
+
+    auto kDynamic = mlir::ShapedType::kDynamic;
+    auto output = rewriter.create<mlir::memref::AllocOp>(loc, mlir::MemRefType::get({kDynamic, kDynamic, 4}, i8Type),
+                                                         mlir::ValueRange{cropH, cropW});
 
     auto ubMap = mlir::AffineMap::get(1, 0, rewriter.getAffineDimExpr(0), rewriter.getContext());
 
@@ -695,33 +555,16 @@ struct CropToAffine : mlir::OpConversionPattern<CropOp> {
     mlir::Value outRow = rowLoop.getInductionVar();
     mlir::Value outCol = colLoop.getInductionVar();
 
-    // map output pixel (outRow, outCol) to input pixel (srcRow, srcCol)
+    // Map output pixel (outRow, outCol) to input pixel (srcRow, srcCol)
     mlir::Value srcRow = rewriter.create<mlir::arith::AddIOp>(loc, yIndex, outRow);
     mlir::Value srcCol = rewriter.create<mlir::arith::AddIOp>(loc, xIndex, outCol);
-
-    // indexMap: (row, col, width) -> (row * width + col) * 4
-    auto indexMap = mlir::AffineMap::get(
-        2, 1, (rewriter.getAffineDimExpr(0) * rewriter.getAffineSymbolExpr(0) + rewriter.getAffineDimExpr(1)) * 4);
-
-    mlir::Value dstPixelBaseIndex =
-        rewriter.create<mlir::affine::AffineApplyOp>(loc, indexMap, mlir::ValueRange{outRow, outCol, cropW});
-    mlir::Value srcPixelBaseIndex =
-        rewriter.create<mlir::affine::AffineApplyOp>(loc, indexMap, mlir::ValueRange{srcRow, srcCol, inputWidth});
 
     auto copyChannel = [&](Channel ch) {
       auto cOffset = rewriter.create<mlir::arith::ConstantIndexOp>(loc, static_cast<int>(ch));
 
-      auto srcAddr = rewriter.create<mlir::arith::AddIOp>(loc, srcPixelBaseIndex, cOffset);
-      auto srcAddrI64 = rewriter.create<mlir::arith::IndexCastOp>(loc, i64Type, srcAddr);
-      auto srcPtr =
-          rewriter.create<mlir::LLVM::GEPOp>(loc, ptrType, i8Type, inputDataPtr, mlir::ValueRange{srcAddrI64});
-      auto srcVal = rewriter.create<mlir::LLVM::LoadOp>(loc, i8Type, srcPtr);
+      auto srcVal = rewriter.create<mlir::memref::LoadOp>(loc, input, mlir::ValueRange{srcRow, srcCol, cOffset});
 
-      auto dstAddr = rewriter.create<mlir::arith::AddIOp>(loc, dstPixelBaseIndex, cOffset);
-      auto dstAddrI64 = rewriter.create<mlir::arith::IndexCastOp>(loc, i64Type, dstAddr);
-      auto dstPtr =
-          rewriter.create<mlir::LLVM::GEPOp>(loc, ptrType, i8Type, outputDataPtr, mlir::ValueRange{dstAddrI64});
-      rewriter.create<mlir::LLVM::StoreOp>(loc, srcVal, dstPtr);
+      rewriter.create<mlir::memref::StoreOp>(loc, srcVal, output, mlir::ValueRange{outRow, outCol, cOffset});
     };
 
     copyChannel(Channel::R);

--- a/tablegen/ops.td
+++ b/tablegen/ops.td
@@ -13,6 +13,11 @@ include "mlir/Interfaces/SideEffectInterfaces.td"
 include "interfaces.td"
 include "types.td"
 
+// Convenience definition for types that can represent an image (either high-level dialect type or low-level memref)
+def Picceler_AnyImageType : AnyTypeOf<[Picceler_ImageType, AnyMemRef]>;
+
+def Picceler_AnyKernelType : AnyTypeOf<[Picceler_KernelType, AnyMemRef]>;
+
 def Picceler_StringConstOp : Op<PiccelerDialect, "string.const"> {
   let summary = "String constant producing a picceler.string";
   let arguments = (ins StrAttr:$value);
@@ -29,18 +34,18 @@ def Picceler_KernelConstOp : Op<PiccelerDialect, "kernel.const", [Pure]> {
 def Picceler_LoadImageOp : Op<PiccelerDialect, "load_image", []> {
   let summary = "Load an image from a file";
   let arguments = (ins Picceler_StringType:$filename);
-  let results = (outs Picceler_ImageType:$result);
+  let results = (outs Picceler_AnyImageType:$result);
 }
 
 def Picceler_SaveImageOp : Op<PiccelerDialect, "save_image", []> {
   let summary = "Save an image to a file";
-  let arguments = (ins Picceler_ImageType:$input, Picceler_StringType:$filename);
+  let arguments = (ins Picceler_AnyImageType:$input, Picceler_StringType:$filename);
   let results = (outs);
 }
 
 def Picceler_ShowImageOp : Op<PiccelerDialect, "show_image", []> {
   let summary = "Show an image in a window";
-  let arguments = (ins Picceler_ImageType:$input);
+  let arguments = (ins Picceler_AnyImageType:$input);
   let results = (outs);
 }
 
@@ -57,8 +62,8 @@ def Picceler_PrintOp : Op<PiccelerDialect, "print", []> {
 
 def Picceler_BrightnessOp : Op<PiccelerDialect, "brightness", [Pure]> {
   let summary = "Adjust the brightness of an image";
-  let arguments = (ins Picceler_ImageType:$input, I64:$value);
-  let results = (outs Picceler_ImageType:$result);
+  let arguments = (ins Picceler_AnyImageType:$input, I64:$value);
+  let results = (outs Picceler_AnyImageType:$result);
 
   let hasVerifier = 1;
   let hasFolder = 1;
@@ -67,8 +72,8 @@ def Picceler_BrightnessOp : Op<PiccelerDialect, "brightness", [Pure]> {
 
 def Picceler_InvertOp : Op<PiccelerDialect, "invert", [Pure]> {
   let summary = "Invert the pixels of an image";
-  let arguments = (ins Picceler_ImageType:$input);
-  let results = (outs Picceler_ImageType:$result);
+  let arguments = (ins Picceler_AnyImageType:$input);
+  let results = (outs Picceler_AnyImageType:$result);
 
   let hasVerifier = 1;
   let hasFolder = 1;
@@ -77,8 +82,8 @@ def Picceler_InvertOp : Op<PiccelerDialect, "invert", [Pure]> {
 
 def Picceler_SharpenOp : Op<PiccelerDialect, "sharpen", [Pure]> {
   let summary = "Adjust the sharpness of an image";
-  let arguments = (ins Picceler_ImageType:$input, I64:$value);
-  let results = (outs Picceler_ImageType:$result);
+  let arguments = (ins Picceler_AnyImageType:$input, I64:$value);
+  let results = (outs Picceler_AnyImageType:$result);
 
   let hasVerifier = 1;
   let hasFolder = 1;
@@ -87,8 +92,8 @@ def Picceler_SharpenOp : Op<PiccelerDialect, "sharpen", [Pure]> {
 
 def Picceler_BoxBlurOp : Op<PiccelerDialect, "box_blur", [Pure]> {
   let summary = "Apply a simple box blur";
-  let arguments = (ins Picceler_ImageType:$input, I64:$radius);
-  let results = (outs Picceler_ImageType:$result);
+  let arguments = (ins Picceler_AnyImageType:$input, I64:$radius);
+  let results = (outs Picceler_AnyImageType:$result);
 
   let hasVerifier = 1;
   let hasFolder = 1;
@@ -97,8 +102,8 @@ def Picceler_BoxBlurOp : Op<PiccelerDialect, "box_blur", [Pure]> {
 
 def Picceler_GaussianBlurOp : Op<PiccelerDialect, "gaussian_blur", [Pure]> {
   let summary = "Apply a gaussian blur (smoother)";
-  let arguments = (ins Picceler_ImageType:$input, I64:$radius);
-  let results = (outs Picceler_ImageType:$result);
+  let arguments = (ins Picceler_AnyImageType:$input, I64:$radius);
+  let results = (outs Picceler_AnyImageType:$result);
 
   let hasVerifier = 1;
   let hasFolder = 1;
@@ -107,8 +112,8 @@ def Picceler_GaussianBlurOp : Op<PiccelerDialect, "gaussian_blur", [Pure]> {
 
 def Picceler_EdgeDetectOp : Op<PiccelerDialect, "edge_detect", [Pure]> {
   let summary = "Detect edges in the image";
-  let arguments = (ins Picceler_ImageType:$input);
-  let results = (outs Picceler_ImageType:$result);
+  let arguments = (ins Picceler_AnyImageType:$input);
+  let results = (outs Picceler_AnyImageType:$result);
 
   let hasVerifier = 1;
   let hasFolder = 1;
@@ -117,8 +122,8 @@ def Picceler_EdgeDetectOp : Op<PiccelerDialect, "edge_detect", [Pure]> {
 
 def Picceler_EmbossOp : Op<PiccelerDialect, "emboss", [Pure]> {
   let summary = "Apply a 3D emboss effect";
-  let arguments = (ins Picceler_ImageType:$input);
-  let results = (outs Picceler_ImageType:$result);
+  let arguments = (ins Picceler_AnyImageType:$input);
+  let results = (outs Picceler_AnyImageType:$result);
 
   let hasVerifier = 1;
   let hasFolder = 1;
@@ -127,8 +132,8 @@ def Picceler_EmbossOp : Op<PiccelerDialect, "emboss", [Pure]> {
 
 def Picceler_RotateOp : Op<PiccelerDialect, "rotate", [Pure]> {
   let summary = "Rotate an image around its center";
-  let arguments = (ins Picceler_ImageType:$input, I64:$angle);
-  let results = (outs Picceler_ImageType:$result);
+  let arguments = (ins Picceler_AnyImageType:$input, I64:$angle);
+  let results = (outs Picceler_AnyImageType:$result);
 
   let hasVerifier = 1;
   let hasFolder = 1;
@@ -139,8 +144,8 @@ def Picceler_ConvolutionOp : Op<PiccelerDialect, "convolution", [Pure, Neighbour
  DeclareOpInterfaceMethods<NeighbourhoodOpInterface, ["initializeAccumulator", "accumulate", "finalizeAccumulator", "getNeighborhoodSize"]>
  ]> {
   let summary = "Apply convolution to an image with a kernel";
-  let arguments = (ins Picceler_ImageType:$input, AnyTypeOf<[Picceler_KernelType, AnyMemRef]>:$kernel);
-  let results = (outs Picceler_ImageType:$result);
+  let arguments = (ins Picceler_AnyImageType:$input, Picceler_AnyKernelType:$kernel);
+  let results = (outs Picceler_AnyImageType:$result);
 
   let hasVerifier = 1;
   let hasFolder = 1;
@@ -152,8 +157,8 @@ def Picceler_ErodeOp : Op<PiccelerDialect, "erode", [Pure, NeighbourhoodOpInterf
   ["initializeAccumulator", "accumulate", "finalizeAccumulator", "getNeighborhoodSize"]>
   ]> {
   let summary = "Apply erosion to an image";
-  let arguments = (ins Picceler_ImageType:$input, I64:$radius);
-  let results = (outs Picceler_ImageType:$result);
+  let arguments = (ins Picceler_AnyImageType:$input, I64:$radius);
+  let results = (outs Picceler_AnyImageType:$result);
 
   let hasVerifier = 1;
   let hasFolder = 1;
@@ -165,8 +170,8 @@ def Picceler_DilateOp : Op<PiccelerDialect, "dilate", [Pure, NeighbourhoodOpInte
   ["initializeAccumulator", "accumulate", "finalizeAccumulator", "getNeighborhoodSize"]>
   ]> {
   let summary = "Apply dilation to an image";
-  let arguments = (ins Picceler_ImageType:$input, I64:$radius);
-  let results = (outs Picceler_ImageType:$result);
+  let arguments = (ins Picceler_AnyImageType:$input, I64:$radius);
+  let results = (outs Picceler_AnyImageType:$result);
 
   let hasVerifier = 1;
   let hasFolder = 1;
@@ -176,8 +181,8 @@ def Picceler_DilateOp : Op<PiccelerDialect, "dilate", [Pure, NeighbourhoodOpInte
 def Picceler_DiffOp : Op<PiccelerDialect, "diff", [Pure, ElementWiseBinaryOpInterface,
  DeclareOpInterfaceMethods<ElementWiseBinaryOpInterface, ["transformPixels"]>]> {
   let summary = "Compute the pixel-wise difference between two images";
-  let arguments = (ins Picceler_ImageType:$input1, Picceler_ImageType:$input2);
-  let results = (outs Picceler_ImageType:$result);
+  let arguments = (ins Picceler_AnyImageType:$input1, Picceler_AnyImageType:$input2);
+  let results = (outs Picceler_AnyImageType:$result);
 
   let hasVerifier = 1;
   let hasFolder = 1;
@@ -187,8 +192,8 @@ def Picceler_DiffOp : Op<PiccelerDialect, "diff", [Pure, ElementWiseBinaryOpInte
 def Picceler_BlendOp : Op<PiccelerDialect, "blend", [Pure,ElementWiseBinaryOpInterface,
  DeclareOpInterfaceMethods<ElementWiseBinaryOpInterface, ["transformPixels"]>]> {
   let summary = "Blend two images together";
-  let arguments = (ins Picceler_ImageType:$input1, Picceler_ImageType:$input2, F64:$weight);
-  let results = (outs Picceler_ImageType:$result);
+  let arguments = (ins Picceler_AnyImageType:$input1, Picceler_AnyImageType:$input2, F64:$weight);
+  let results = (outs Picceler_AnyImageType:$result);
 
   let hasVerifier = 1;
   let hasFolder = 1;
@@ -197,8 +202,8 @@ def Picceler_BlendOp : Op<PiccelerDialect, "blend", [Pure,ElementWiseBinaryOpInt
 
 def Picceler_CropOp : Op<PiccelerDialect, "crop", [Pure]> {
   let summary = "Crop an image to a rectangular region";
-  let arguments = (ins Picceler_ImageType:$input, I64:$x, I64:$y, I64:$width, I64:$height);
-  let results = (outs Picceler_ImageType:$result);
+  let arguments = (ins Picceler_AnyImageType:$input, I64:$x, I64:$y, I64:$width, I64:$height);
+  let results = (outs Picceler_AnyImageType:$result);
 
   let hasVerifier = 1;
   let hasFolder = 1;

--- a/tablegen/passes.td
+++ b/tablegen/passes.td
@@ -42,6 +42,13 @@ def PiccelerToAffine : Pass<"picceler-to-affine", "mlir::ModuleOp"> {
 def PiccelerOpsToFuncCalls : Pass<"picceler-ops-to-func-calls", "mlir::ModuleOp"> {
   let summary = "Lower Picceler Heavy-Ops to function calls";
   let constructor = "picceler::createPiccelerOpsToFuncCallsPass()";
+
+  let dependentDialects = [
+    "mlir::arith::ArithDialect",
+    "mlir::func::FuncDialect",
+    "mlir::memref::MemRefDialect",
+    "mlir::LLVM::LLVMDialect"
+    ];
 }
 
 def PiccelerToLLVMIR : Pass<"picceler-to-llvmir", "mlir::ModuleOp"> {


### PR DESCRIPTION
So far we had all computational ops expecting llvm.ptr, but it is very beneficial to change this to `memref`s, there is room for much more optimisation from MLIR existing passes this way, and this PR addresses that.

fixes #92 